### PR TITLE
chore: export CSS type with default config set

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -90,3 +90,5 @@ export {
   config,
   customColors,
 } from './stitches.config';
+
+export type { CSS } from './stitches.config';

--- a/stitches.config.ts
+++ b/stitches.config.ts
@@ -403,7 +403,7 @@ const stitches = createStitches({
   },
 });
 
-export type CSS = StitchesCSS<typeof stitches.config>;
+export type CSS<T = typeof stitches.config> = StitchesCSS<T>;
 
 export const { styled, css, createTheme, getCssText, globalCss, keyframes, config } = stitches;
 


### PR DESCRIPTION
This PR aims to make it easier to import the `CSS` interface with all Stitches configuration defined by default.
