### PR TITLE
fix: Card interactive, add cursor pointer

### DIFF
--- a/components/Card/Card.tsx
+++ b/components/Card/Card.tsx
@@ -47,6 +47,7 @@ export const Card = styled('div', {
       true: {
         '@hover': {
           '&:hover': {
+            cursor: 'pointer',
             '&::before': {
               boxShadow: 'inset 0 0 0 1px $colors$cardHoverBorder',
               backgroundColor: '$cardHoverBackground',


### PR DESCRIPTION
#### Description

Add `cursor: 'pointer'` on hover for interactive card