### PR TITLE
fix: input adornments josep feedback

### DIFF
--- a/components/Input/Input.stories.tsx
+++ b/components/Input/Input.stories.tsx
@@ -3,7 +3,6 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { styled } from '../../stitches.config';
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
 
-import { IconButton } from '../IconButton';
 import { Input, InputProps, InputVariants } from './Input';
 import { Box } from '../Box';
 import { Flex } from '../Flex';
@@ -11,12 +10,12 @@ import { Label } from '../Label';
 
 import { MagnifyingGlassIcon, EyeOpenIcon } from '@radix-ui/react-icons';
 
-const StyledMagnifyingGlassIcon = styled(MagnifyingGlassIcon, {
-  color: '$slate10', // follow iconbutton default color
-});
-
 const StyledEyeOpenIcon = styled(EyeOpenIcon, {
-  color: '$slate10', // follow iconbutton default color
+  '@hover': {
+    '&:hover': {
+      cursor: 'pointer',
+    }
+  }
 });
 
 const BaseInput = (props: InputProps): JSX.Element => <Input {...props} />;
@@ -58,11 +57,9 @@ export const Basic: ComponentStory<typeof InputForStory> = (args) => (
     <Box>
       <Label>Adornments</Label>
       <InputForStory
-        startAdornment={<StyledMagnifyingGlassIcon />}
+        startAdornment={<MagnifyingGlassIcon />}
         endAdornment={
-          <IconButton>
-            <StyledEyeOpenIcon />
-          </IconButton>
+          <StyledEyeOpenIcon />
         }
         {...args}
       />
@@ -147,11 +144,9 @@ export const Ghost: ComponentStory<typeof InputForStory> = (args) => (
     <Label>
       Adornments
       <InputForStory
-        startAdornment={<StyledMagnifyingGlassIcon />}
+        startAdornment={<MagnifyingGlassIcon />}
         endAdornment={
-          <IconButton>
-            <StyledEyeOpenIcon />
-          </IconButton>
+          <StyledEyeOpenIcon />
         }
         {...args}
       />
@@ -163,33 +158,27 @@ Ghost.args = { defaultValue: 'value', variant: 'ghost' };
 export const Adornments = Basic.bind({});
 
 Adornments.args = {
-  startAdornment: <StyledMagnifyingGlassIcon />,
+  startAdornment: <MagnifyingGlassIcon />,
   endAdornment: (
-    <IconButton>
-      <StyledEyeOpenIcon />
-    </IconButton>
+    <StyledEyeOpenIcon />
   ),
 };
 Adornments.argTypes = {
   startAdornment: {
-    options: ['search', 'iconbutton'],
+    options: ['search', 'eye'],
     mapping: {
-      search: <StyledMagnifyingGlassIcon />,
-      iconbutton: (
-        <IconButton>
-          <StyledEyeOpenIcon />
-        </IconButton>
+      search: <MagnifyingGlassIcon />,
+      eye: (
+        <StyledEyeOpenIcon />
       ),
     },
   },
   endAdornment: {
-    options: ['search', 'iconbutton'],
+    options: ['search', 'eye'],
     mapping: {
-      search: <StyledMagnifyingGlassIcon />,
-      iconbutton: (
-        <IconButton>
-          <StyledEyeOpenIcon />
-        </IconButton>
+      search: <MagnifyingGlassIcon />,
+      eye: (
+        <StyledEyeOpenIcon />
       ),
     },
   },
@@ -238,11 +227,9 @@ export const Autofill: ComponentStory<typeof InputForStory> = (args) => (
         <InputForStory
           name="ship-country"
           autoComplete="shipping country"
-          startAdornment={<StyledMagnifyingGlassIcon />}
+          startAdornment={<MagnifyingGlassIcon />}
           endAdornment={
-            <IconButton>
-              <StyledEyeOpenIcon />
-            </IconButton>
+            <StyledEyeOpenIcon />
           }
           {...args}
         />

--- a/components/Input/Input.tsx
+++ b/components/Input/Input.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { VariantProps } from '@stitches/react';
 import { styled, CSS } from '../../stitches.config';
 import { elevationVariant } from '../Elevation';
-import { IconButton } from '../IconButton';
 
 // CONSTANTS
 const FOCUS_SHADOW = elevationVariant[1].boxShadow; // apply elevation $1 when focus
@@ -328,21 +327,12 @@ const AdornmentWrapper = styled('div', {
     size: {
       small: {
         mx: 'calc($2 / 2)',
-        [`& ${IconButton}`]: {
-          size: SMALL_HEIGHT,
-        },
       },
       medium: {
         mx: 'calc($3 / 2)',
-        [`& ${IconButton}`]: {
-          size: MEDIUM_HEIGHT,
-        },
       },
       large: {
         mx: 'calc($3 / 2)',
-        [`& ${IconButton}`]: {
-          size: LARGE_HEIGHT,
-        },
       },
     },
     variant: {
@@ -361,60 +351,10 @@ const AdornmentWrapper = styled('div', {
 
 const AdornmentWrapperStart = styled(AdornmentWrapper, {
   left: 0,
-  variants: {
-    size: {
-      small: {
-        [`& ${IconButton}:first-of-type`]: {
-          // remove start margin for first IconButton
-          marginInlineStart: 'calc(-$2 / 2)',
-        },
-      },
-      medium: {
-        [`& ${IconButton}:first-of-type`]: {
-          // remove start margin for first IconButton
-          marginInlineStart: 'calc(-$3 / 2)',
-        },
-      },
-      large: {
-        [`& ${IconButton}:first-of-type`]: {
-          // remove start margin for first IconButton
-          marginInlineStart: 'calc(-$3 / 2)',
-        },
-      },
-    },
-  },
-  defaultVariants: {
-    size: 'medium',
-  },
 });
 
 const AdornmentWrapperEnd = styled(AdornmentWrapper, {
   right: 0,
-  variants: {
-    size: {
-      small: {
-        [`& ${IconButton}:last-of-type`]: {
-          // remove start margin for last IconButton
-          marginInlineEnd: 'calc(-$2 / 2)',
-        },
-      },
-      medium: {
-        [`& ${IconButton}:last-of-type`]: {
-          // remove start margin for last IconButton
-          marginInlineEnd: 'calc(-$3 / 2)',
-        },
-      },
-      large: {
-        [`& ${IconButton}:last-of-type`]: {
-          // remove start margin for last IconButton
-          marginInlineEnd: 'calc(-$3 / 2)',
-        },
-      },
-    },
-  },
-  defaultVariants: {
-    size: 'medium',
-  },
 });
 
 type DefaultInputVariants = VariantProps<typeof StyledInput>;

--- a/components/Input/Input.tsx
+++ b/components/Input/Input.tsx
@@ -324,9 +324,6 @@ const AdornmentWrapper = styled('div', {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  [`& ${IconButton}:focus-visible`]: {
-    color: '$inputFocusBorder',
-  },
   variants: {
     size: {
       small: {

--- a/components/TextField/TextField.tsx
+++ b/components/TextField/TextField.tsx
@@ -4,6 +4,7 @@ import { styled } from '../../stitches.config';
 import { Box } from '../Box';
 import { Input, InputHandle, InputProps, InputVariants } from '../Input';
 import { Label } from '../Label';
+import { Tooltip } from '../Tooltip';
 import {
   ExclamationTriangleIcon,
   CrossCircledIcon,
@@ -142,7 +143,12 @@ export const TextField = React.forwardRef<React.ElementRef<typeof Input>, TextFi
     );
 
     const PasswordVisibilityToggleIcon = React.useMemo(
-      () => isPasswordVisible ? StyledEyeClosedIcon : StyledEyeOpenIcon,
+      () => isPasswordVisible ? StyledEyeOpenIcon : StyledEyeClosedIcon,
+      [isPasswordVisible],
+    );
+
+    const passwordTooltipContent = React.useMemo(
+      () => isPasswordVisible ? "Hide password" : "Show password",
       [isPasswordVisible],
     );
 
@@ -161,10 +167,14 @@ export const TextField = React.forwardRef<React.ElementRef<typeof Input>, TextFi
               <EndAdornmentWrapper>
                 {invalid && <StyledExclamationTriangleIcon />}
                 {isPasswordType && (
-                  <PasswordVisibilityToggleIcon onClick={togglePasswordVisibility} />
+                  <Tooltip content={passwordTooltipContent}>
+                    <PasswordVisibilityToggleIcon onClick={togglePasswordVisibility} />
+                  </Tooltip>
                 )}
                 {clearable && !clearDisabled && (
-                  <StyledCrossCircledIcon onClick={handleClear} />
+                  <Tooltip content="Clear">
+                    <StyledCrossCircledIcon onClick={handleClear} />
+                  </Tooltip>
                 )}
               </EndAdornmentWrapper>
             )

--- a/components/TextField/TextField.tsx
+++ b/components/TextField/TextField.tsx
@@ -143,7 +143,7 @@ export const TextField = React.forwardRef<React.ElementRef<typeof Input>, TextFi
     );
 
     const PasswordVisibilityToggleIcon = React.useMemo(
-      () => isPasswordVisible ? StyledEyeOpenIcon : StyledEyeClosedIcon,
+      () => isPasswordVisible ? StyledEyeClosedIcon : StyledEyeOpenIcon,
       [isPasswordVisible],
     );
 

--- a/components/TextField/TextField.tsx
+++ b/components/TextField/TextField.tsx
@@ -147,7 +147,7 @@ export const TextField = React.forwardRef<React.ElementRef<typeof Input>, TextFi
       [isPasswordVisible],
     );
 
-    const passwordTooltipContent = React.useMemo(
+    const passwordAction = React.useMemo(
       () => isPasswordVisible ? "Hide password" : "Show password",
       [isPasswordVisible],
     );
@@ -165,15 +165,15 @@ export const TextField = React.forwardRef<React.ElementRef<typeof Input>, TextFi
           endAdornment={
             hasInnerAdornment && (
               <EndAdornmentWrapper>
-                {invalid && <StyledExclamationTriangleIcon />}
+                {invalid && <StyledExclamationTriangleIcon role="alert" aria-label="Invalid" />}
                 {isPasswordType && (
-                  <Tooltip content={passwordTooltipContent}>
-                    <PasswordVisibilityToggleIcon onClick={togglePasswordVisibility} />
+                  <Tooltip content={passwordAction}>
+                    <PasswordVisibilityToggleIcon aria-label={passwordAction} onClick={togglePasswordVisibility} />
                   </Tooltip>
                 )}
                 {clearable && !clearDisabled && (
                   <Tooltip content="Clear">
-                    <StyledCrossCircledIcon onClick={handleClear} />
+                    <StyledCrossCircledIcon aria-label="Clear" onClick={handleClear} />
                   </Tooltip>
                 )}
               </EndAdornmentWrapper>

--- a/components/TextField/TextField.tsx
+++ b/components/TextField/TextField.tsx
@@ -4,7 +4,6 @@ import { styled } from '../../stitches.config';
 import { Box } from '../Box';
 import { Input, InputHandle, InputProps, InputVariants } from '../Input';
 import { Label } from '../Label';
-import { IconButton } from '../IconButton';
 import {
   ExclamationTriangleIcon,
   CrossCircledIcon,
@@ -32,6 +31,30 @@ const StyledExclamationTriangleIcon = styled(ExclamationTriangleIcon, {
   '& + *': {
     marginLeft: '$1',
   },
+});
+
+const StyledEyeOpenIcon = styled(EyeOpenIcon, {
+  '@hover': {
+    '&:hover': {
+      cursor: 'pointer',
+    }
+  }
+});
+
+const StyledEyeClosedIcon = styled(EyeClosedIcon, {
+  '@hover': {
+    '&:hover': {
+      cursor: 'pointer'
+    }
+  }
+});
+
+const StyledCrossCircledIcon = styled(CrossCircledIcon, {
+  '@hover': {
+    '&:hover': {
+      cursor: 'pointer'
+    }
+  }
 });
 
 export const TextField = React.forwardRef<React.ElementRef<typeof Input>, TextFieldProps>(
@@ -118,6 +141,11 @@ export const TextField = React.forwardRef<React.ElementRef<typeof Input>, TextFi
       [hasAdornmentGroup]
     );
 
+    const PasswordVisibilityToggleIcon = React.useMemo(
+      () => isPasswordVisible ? StyledEyeClosedIcon : StyledEyeOpenIcon,
+      [isPasswordVisible],
+    );
+
     return (
       <Box css={css}>
         {label && (
@@ -133,14 +161,10 @@ export const TextField = React.forwardRef<React.ElementRef<typeof Input>, TextFi
               <EndAdornmentWrapper>
                 {invalid && <StyledExclamationTriangleIcon />}
                 {isPasswordType && (
-                  <IconButton type="button" onClick={togglePasswordVisibility} size="1">
-                    {isPasswordVisible ? <EyeClosedIcon /> : <EyeOpenIcon />}
-                  </IconButton>
+                  <PasswordVisibilityToggleIcon onClick={togglePasswordVisibility} />
                 )}
-                {clearable && (
-                  <IconButton disabled={clearDisabled} type="button" onClick={handleClear} size="1">
-                    <CrossCircledIcon />
-                  </IconButton>
+                {clearable && !clearDisabled && (
+                  <StyledCrossCircledIcon onClick={handleClear} />
                 )}
               </EndAdornmentWrapper>
             )


### PR DESCRIPTION
#### Description

On [TextField mockup](https://app.zeplin.io/project/61497d608f9b6e598e281a34/screen/61497eadad40de21822f2aac), Josep recommended to remove any hover/focus interaction for input adornments.

- Replaced IconButton by simple icons with cusor: pointer behaviour on hover
- Removed IconButton integration from input AdornmentWrapper
- Input stories, removed IconButton as adornment