### PR TITLE
fix: select style consistency with input one

### DIFF
--- a/components/Input/Input.themes.ts
+++ b/components/Input/Input.themes.ts
@@ -3,7 +3,7 @@ import tinycolor from 'tinycolor2';
 import { ColorInfo } from '../../utils/getPrimaryColorInfo';
 
 export namespace Theme {
-  type Colors = {
+  export type Colors = {
     inputBg: Property.Color;
     inputBorder: Property.Color;
     inputFocusBg: Property.Color;

--- a/components/Input/Input.tsx
+++ b/components/Input/Input.tsx
@@ -230,19 +230,13 @@ const InputWrapper = styled('div', {
     boxSizing: 'border-box',
     content: '""',
     position: 'absolute',
-    top: 0,
-    right: 0,
-    bottom: 0,
-    left: 0,
+    inset: 0,
   },
   '&::after': {
     boxSizing: 'border-box',
     content: '""',
     position: 'absolute',
-    top: 0,
-    right: 0,
-    bottom: 0,
-    left: 0,
+    inset: 0,
   },
 
   '&:focus-visible': {

--- a/components/Select/Select.stories.tsx
+++ b/components/Select/Select.stories.tsx
@@ -29,17 +29,17 @@ export const Basic = Template.bind({});
 
 Basic.args = {};
 
-export const Large = Template.bind({});
+export const Size = Template.bind({});
 
-Large.args = { size: 'large', placeholder: 'placeholder' };
+Size.args = { size: 'large', placeholder: 'placeholder' };
 
-export const Ghost = Template.bind({});
+export const Variant = Template.bind({});
 
-Ghost.args = { variant: 'ghost', value: 'value' };
+Variant.args = { variant: 'ghost', value: 'value' };
 
-export const Invalid = Template.bind({});
+export const State = Template.bind({});
 
-Invalid.args = { state: 'invalid' };
+State.args = { state: 'invalid' };
 
 export const Disabled = Template.bind({});
 

--- a/components/Select/Select.stories.tsx
+++ b/components/Select/Select.stories.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
-import { BaseSelect, SelectProps, SelectVariants } from './Select';
+import { Select, SelectProps, SelectVariants } from './Select';
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
 
+const BaseSelect = (props: SelectProps): JSX.Element => <Select {...props} />;
 const SelectForStory = modifyVariantsForStory<
   SelectVariants,
   SelectProps & React.InputHTMLAttributes<any>

--- a/components/Select/Select.stories.tsx
+++ b/components/Select/Select.stories.tsx
@@ -17,11 +17,11 @@ export default {
 
 const Template: ComponentStory<typeof SelectForStory> = (args) => (
   <SelectForStory {...args}>
-    <option>Option 1</option>
-    <option>Option 2</option>
-    <option>Option 3</option>
-    <option>Option 4</option>
-    <option>Option 5</option>
+    <option value="option1">Option 1</option>
+    <option value="option2">Option 2</option>
+    <option value="option3">Option 3</option>
+    <option value="option4">Option 4</option>
+    <option value="option5">Option 5</option>
   </SelectForStory>
 );
 
@@ -35,7 +35,7 @@ Size.args = { size: 'large', placeholder: 'placeholder' };
 
 export const Variant = Template.bind({});
 
-Variant.args = { variant: 'ghost', value: 'value' };
+Variant.args = { variant: 'ghost', defaultValue: 'option3' };
 
 export const State = Template.bind({});
 
@@ -43,8 +43,8 @@ State.args = { state: 'invalid' };
 
 export const Disabled = Template.bind({});
 
-Disabled.args = { disabled: true, value: 'value' };
+Disabled.args = { disabled: true, defaultValue: 'option3' };
 
 export const ReadOnly = Template.bind({});
 
-ReadOnly.args = { readOnly: true, value: 'value' };
+ReadOnly.args = { readOnly: true, defaultValue: 'option3' };

--- a/components/Select/Select.stories.tsx
+++ b/components/Select/Select.stories.tsx
@@ -44,7 +44,3 @@ State.args = { state: 'invalid' };
 export const Disabled = Template.bind({});
 
 Disabled.args = { disabled: true, defaultValue: 'option3' };
-
-export const ReadOnly = Template.bind({});
-
-ReadOnly.args = { readOnly: true, defaultValue: 'option3' };

--- a/components/Select/Select.themes.ts
+++ b/components/Select/Select.themes.ts
@@ -16,8 +16,9 @@ export namespace Theme {
   };
 
   type Factory = (primaryColor: ColorInfo) => Colors;
+  type FactoryMapper = (colors: InputTheme.Colors) => Colors;
 
-  const remapInputTheme = (inputLightOrDark) => ({
+  const remapInputTheme: FactoryMapper = (inputLightOrDark) => ({
     selectBg: inputLightOrDark.inputBg,
     selectBorder: inputLightOrDark.inputBorder,
     selectFocusBg: inputLightOrDark.inputFocusBg,

--- a/components/Select/Select.themes.ts
+++ b/components/Select/Select.themes.ts
@@ -1,6 +1,6 @@
 import { Property } from '@stitches/react/types/css';
 import { ColorInfo } from '../../utils/getPrimaryColorInfo';
-import tinycolor from 'tinycolor2';
+import { Theme as InputTheme } from '../Input/Input.themes';
 
 export namespace Theme {
   type Colors = {
@@ -17,27 +17,23 @@ export namespace Theme {
 
   type Factory = (primaryColor: ColorInfo) => Colors;
 
+  const remapInputTheme = (inputLightOrDark) => ({
+    selectBg: inputLightOrDark.inputBg,
+    selectBorder: inputLightOrDark.inputBorder,
+    selectFocusBg: inputLightOrDark.inputFocusBg,
+    selectFocusBorder: inputLightOrDark.inputFocusBorder,
+    selectHoverBg: inputLightOrDark.inputHoverBg,
+    selectText: inputLightOrDark.inputText,
+    selectPlaceholder: inputLightOrDark.inputPlaceholder,
+    selectDisabledText: inputLightOrDark.inputDisabledText,
+    selectInvalidBorder: inputLightOrDark.inputInvalidBorder,
+  });
+
   export const getLight: Factory = (primaryColor) => ({
-    selectBg: '$deepBlue1',
-    selectBorder: '$grayBlue9',
-    selectFocusBg: tinycolor('black').setAlpha(0.15).toHslString(),
-    selectFocusBorder: primaryColor.helpers.pickScale(8),
-    selectHoverBg: '$whiteA9',
-    selectText: tinycolor('black').setAlpha(0.74).toHslString(),
-    selectPlaceholder: '$blackA10',
-    selectDisabledText: tinycolor('black').setAlpha(0.35).toHslString(),
-    selectInvalidBorder: '$red9',
+    ...remapInputTheme(InputTheme.getLight(primaryColor)),
   });
 
   export const getDark: Factory = (primaryColor) => ({
-    selectBg: '$grayBlue7',
-    selectBorder: '$grayBlue9',
-    selectFocusBg: tinycolor('black').setAlpha(0.15).toHslString(),
-    selectFocusBorder: primaryColor.helpers.pickScale(11),
-    selectHoverBg: '$whiteA4',
-    selectText: tinycolor('white').setAlpha(0.8).toHslString(),
-    selectPlaceholder: '$whiteA10',
-    selectDisabledText: tinycolor('white').setAlpha(0.35).toHslString(),
-    selectInvalidBorder: '$red9',
+    ...remapInputTheme(InputTheme.getDark(primaryColor)),
   });
 }

--- a/components/Select/Select.themes.ts
+++ b/components/Select/Select.themes.ts
@@ -1,5 +1,6 @@
 import { Property } from '@stitches/react/types/css';
 import { ColorInfo } from '../../utils/getPrimaryColorInfo';
+import tinycolor from 'tinycolor2';
 
 export namespace Theme {
   type Colors = {
@@ -11,35 +12,32 @@ export namespace Theme {
     selectText: Property.Color;
     selectPlaceholder: Property.Color;
     selectDisabledText: Property.Color;
-    selectDisabledBorder: Property.Color;
-    selectReadOnlyBg: Property.Color;
+    selectInvalidBorder: Property.Color;
   };
 
-  type Factory = (primaryColor?: ColorInfo) => Colors;
+  type Factory = (primaryColor: ColorInfo) => Colors;
 
-  export const getLight: Factory = () => ({
-    selectBg: '$deepBlue3',
-    selectBorder: '$deepBlue6',
-    selectFocusBg: '$deepBlue2',
-    selectFocusBorder: '$deepBlue10',
-    selectHoverBg: '$deepBlue2',
-    selectText: '$deepBlue9',
-    selectPlaceholder: '$deepBlue6',
-    selectDisabledText: '$deepBlue5',
-    selectDisabledBorder: '$deepBlue5',
-    selectReadOnlyBg: '$deepBlue3',
+  export const getLight: Factory = (primaryColor) => ({
+    selectBg: '$deepBlue1',
+    selectBorder: '$grayBlue9',
+    selectFocusBg: tinycolor('black').setAlpha(0.15).toHslString(),
+    selectFocusBorder: primaryColor.helpers.pickScale(8),
+    selectHoverBg: '$whiteA9',
+    selectText: tinycolor('black').setAlpha(0.74).toHslString(),
+    selectPlaceholder: '$blackA10',
+    selectDisabledText: tinycolor('black').setAlpha(0.35).toHslString(),
+    selectInvalidBorder: '$red9',
   });
 
-  export const getDark: Factory = () => ({
-    selectBg: '$deepBlue3',
-    selectBorder: '$deepBlue6',
-    selectFocusBg: '$deepBlue1',
-    selectFocusBorder: '$deepBlue9',
-    selectHoverBg: '$deepBlue1',
-    selectText: '$deepBlue9',
-    selectPlaceholder: '$deepBlue6',
-    selectDisabledText: '$deepBlue5',
-    selectDisabledBorder: '$deepBlue4',
-    selectReadOnlyBg: '$deepBlue2',
+  export const getDark: Factory = (primaryColor) => ({
+    selectBg: '$grayBlue7',
+    selectBorder: '$grayBlue9',
+    selectFocusBg: tinycolor('black').setAlpha(0.15).toHslString(),
+    selectFocusBorder: primaryColor.helpers.pickScale(11),
+    selectHoverBg: '$whiteA4',
+    selectText: tinycolor('white').setAlpha(0.8).toHslString(),
+    selectPlaceholder: '$whiteA10',
+    selectDisabledText: tinycolor('white').setAlpha(0.35).toHslString(),
+    selectInvalidBorder: '$red9',
   });
 }

--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -60,6 +60,10 @@ const StyledSelect = styled('select', {
   pr: '$3',
   lineHeight: '25px',
 
+  '& option': {
+    color: '$loContrast',
+  },
+
   '&:focus-visible': {
     boxShadow: `inset 0 0 0 2px $colors$selectFocusBorder, ${FOCUS_SHADOW}`,
   },

--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -72,10 +72,6 @@ const StyledSelect = styled('select', {
     pointerEvents: 'none',
     color: '$selectDisabledText',
   },
-
-  '&:read-only': {
-    pointerEvents: 'none',
-  },
 });
 
 const SelectWrapper = styled('div', {

--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -73,7 +73,7 @@ const StyledSelect = styled('select', {
     color: '$selectDisabledText',
   },
 
-  '&[readonly]': {
+  '&:read-only': {
     pointerEvents: 'none',
   },
 });

--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -61,7 +61,8 @@ const StyledSelect = styled('select', {
   lineHeight: '25px',
 
   '& option': {
-    color: '$loContrast',
+    color: 'black',
+    bc: 'white',
   },
 
   '&:focus-visible': {

--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -72,6 +72,10 @@ const StyledSelect = styled('select', {
     pointerEvents: 'none',
     color: '$selectDisabledText',
   },
+
+  '&[readonly]': {
+    pointerEvents: 'none',
+  },
 });
 
 const SelectWrapper = styled('div', {

--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -2,133 +2,10 @@ import React from 'react';
 import { styled, CSS } from '../../stitches.config';
 import { CaretSortIcon } from '@radix-ui/react-icons';
 import { VariantProps } from '@stitches/react';
+import { elevationVariant } from '../Elevation';
 
-const StyledSelect = styled('select', {
-  appearance: 'none',
-  backgroundColor: 'transparent',
-  border: 'none',
-  borderRadius: 'inherit',
-  color: 'inherit',
-  font: 'inherit',
-  outline: 'none',
-  width: '100%',
-  height: '100%',
-  pl: '$1',
-  pr: '$3',
-  lineHeight: '25px',
-
-  '&:disabled': {
-    color: '$selectDisabledText',
-  },
-});
-
-const SelectWrapper = styled('div', {
-  backgroundColor: '$selectBg',
-  borderRadius: '$2',
-  boxShadow: 'inset 0 0 0 1px $colors$selectBorder',
-  color: '$selectText',
-  fontFamily: '$rubik',
-  fontSize: '$1',
-  fontVariantNumeric: 'tabular-nums',
-  fontWeight: 400,
-  height: '$5',
-  flexShrink: 0,
-
-  '&:focus-within': {
-    zIndex: 1,
-    backgroundColor: '$selectFocusBg',
-    boxShadow:
-      'inset 0px 0px 0px 1px $colors$selectFocusBorder, 0px 0px 0px 1px $colors$selectFocusBorder',
-  },
-
-  '&:-webkit-autofill': {
-    boxShadow: 'inset 0 0 0 2px $colors$selectBorder, inset 0 0 0 100px $colors$selectBg',
-  },
-
-  '&:-webkit-autofill::first-line': {
-    fontFamily: '$rubik',
-    color: '$hiContrast',
-  },
-
-  '@hover': {
-    '&:hover': {
-      backgroundColor: '$selectHoverBg',
-    },
-  },
-
-  variants: {
-    disabled: {
-      true: {
-        pointerEvents: 'none',
-        backgroundColor: '$selectBg',
-        boxShadow:
-          'inset 0px 0px 0px 1px $colors$selectDisabledBorder, 0px 0px 0px 1px $colors$selectDisabledBorder',
-        color: '$selectDisabledText',
-      },
-    },
-    size: {
-      small: {
-        borderRadius: '$2',
-        height: '$5',
-        fontSize: '$1',
-        px: '$2',
-        lineHeight: '$sizes$5',
-        '&:-webkit-autofill::first-line': {
-          fontSize: '$1',
-        },
-      },
-      medium: {
-        borderRadius: '$3',
-        height: '$6',
-        fontSize: '$3',
-        px: '$3',
-        lineHeight: '$sizes$6',
-        '&:-webkit-autofill::first-line': {
-          fontSize: '$3',
-        },
-      },
-      large: {
-        borderRadius: '$3',
-        height: '$7',
-        fontSize: '$3',
-        px: '$3',
-        lineHeight: '$sizes$7',
-        '&:-webkit-autofill::first-line': {
-          fontSize: '$3',
-        },
-      },
-    },
-    variant: {
-      ghost: {
-        boxShadow: 'none',
-        backgroundColor: 'transparent',
-        '@hover': {
-          '&:hover': {
-            boxShadow: 'inset 0 0 0 1px $colors$slateA7',
-            backgroundColor: '$selectHoverBg',
-          },
-        },
-        '&:focus-within': {
-          backgroundColor: '$loContrast',
-          boxShadow:
-            'inset 0px 0px 0px 1px $colors$selectFocusBorder, 0px 0px 0px 1px $colors$selectFocusBorder',
-        },
-      },
-    },
-    state: {
-      invalid: {
-        boxShadow: 'inset 0 0 0 2px $colors$red9',
-        '&:focus-within': {
-          backgroundColor: '$selectBg',
-          boxShadow: 'inset 0 0 0 2px $colors$red9',
-        },
-      },
-    },
-  },
-  defaultVariants: {
-    size: 'medium',
-  },
-});
+// CONSTANTS
+const FOCUS_SHADOW = elevationVariant[1].boxShadow; // apply elevation $1 when focus
 
 const StyledCaretSortIcon = styled(CaretSortIcon, {
   position: 'absolute',
@@ -169,22 +46,178 @@ const StyledCaretSortIcon = styled(CaretSortIcon, {
   },
 });
 
+const StyledSelect = styled('select', {
+  appearance: 'none',
+  backgroundColor: 'transparent',
+  border: 'none',
+  borderRadius: 'inherit',
+  color: 'inherit',
+  font: 'inherit',
+  outline: 'none',
+  width: '100%',
+  height: '100%',
+  pl: '$1',
+  pr: '$3',
+  lineHeight: '25px',
+
+  '&:focus-visible': {
+    boxShadow: `inset 0 0 0 2px $colors$selectFocusBorder, ${FOCUS_SHADOW}`,
+  },
+
+  '&:disabled': {
+    pointerEvents: 'none',
+    color: '$selectDisabledText',
+  },
+});
+
+const SelectWrapper = styled('div', {
+  position: 'relative',
+  backgroundColor: '$selectBg',
+  borderRadius: '$2',
+  boxShadow: 'inset 0 0 0 1px $colors$selectBorder',
+  color: '$selectText',
+  fontFamily: '$rubik',
+  fontSize: '$1',
+  fontVariantNumeric: 'tabular-nums',
+  fontWeight: 400,
+  height: '$5',
+  flexShrink: 0,
+
+  '&::before': {
+    boxSizing: 'border-box',
+    content: '""',
+    position: 'absolute',
+    inset: 0,
+    pointerEvents: 'none',
+  },
+  '&::after': {
+    boxSizing: 'border-box',
+    content: '""',
+    position: 'absolute',
+    inset: 0,
+    pointerEvents: 'none',
+  },
+
+  '&:focus-visible': {
+    '&::before': {
+      backgroundColor: '$selectFocusBg',
+    },
+    '&::after': {
+      backgroundColor: '$primary',
+      opacity: 0.15,
+    },
+  },
+
+  '@hover': {
+    '&:hover': {
+      '&::before': {
+        backgroundColor: '$selectHoverBg',
+      },
+      '&::after': {
+        backgroundColor: '$primary',
+        opacity: 0.05,
+      },
+    },
+  },
+
+  variants: {
+    disabled: {
+      true: {
+        opacity: 0.7,
+        color: '$selectDisabledText',
+        '@hover': {
+          '&:hover': {
+            '&::before': {
+              display: 'none',
+            },
+            '&::after': {
+              display: 'none',
+            },
+          },
+        },
+      },
+    },
+    size: {
+      small: {
+        borderRadius: '$2',
+        height: '$5',
+        fontSize: '$1',
+        lineHeight: '$sizes$5',
+        '&:-webkit-autofill::first-line': {
+          fontSize: '$1',
+        },
+        [`& ${StyledSelect}`]: {
+          px: '$2',
+        },
+        [`& ${StyledCaretSortIcon}`]: {
+          right: '$2',
+        },
+      },
+      medium: {
+        borderRadius: '$3',
+        height: '$6',
+        fontSize: '$3',
+        lineHeight: '$sizes$6',
+        '&:-webkit-autofill::first-line': {
+          fontSize: '$3',
+        },
+        [`& ${StyledSelect}`]: {
+          px: '$3',
+        },
+        [`& ${StyledCaretSortIcon}`]: {
+          right: '$3',
+        },
+      },
+      large: {
+        borderRadius: '$3',
+        height: '$7',
+        fontSize: '$3',
+        lineHeight: '$sizes$7',
+        '&:-webkit-autofill::first-line': {
+          fontSize: '$3',
+        },
+        [`& ${StyledSelect}`]: {
+          px: '$3',
+        },
+        [`& ${StyledCaretSortIcon}`]: {
+          right: '$3',
+        },
+      },
+    },
+    variant: {
+      ghost: {
+        boxShadow: 'none',
+        backgroundColor: 'transparent',
+        '@hover': {
+          '&:hover': {
+            boxShadow: 'inset 0 0 0 1px $colors$slateA7',
+            backgroundColor: '$selectHoverBg',
+          },
+        },
+        '&:focus-within': {
+          backgroundColor: '$loContrast',
+          boxShadow:
+            'inset 0px 0px 0px 1px $colors$selectFocusBorder, 0px 0px 0px 1px $colors$selectFocusBorder',
+        },
+      },
+    },
+    state: {
+      invalid: {
+        boxShadow: 'inset 0 0 0 1px $colors$selectInvalidBorder',
+        '&:focus-visible': {
+          boxShadow: `inset 0 0 0 2px $colors$selectInvalidBorder, ${FOCUS_SHADOW}`,
+        },
+      },
+    },
+  },
+  defaultVariants: {
+    size: 'medium',
+  },
+});
+
 export type SelectProps = React.ComponentProps<typeof StyledSelect> &
   React.ComponentProps<typeof SelectWrapper> & { css?: CSS };
 export type SelectVariants = VariantProps<typeof SelectWrapper>;
-
-export const BaseSelect = ({ css, size, state, variant, ...props }: SelectProps): JSX.Element => (
-  <SelectWrapper
-    css={css as any}
-    size={size}
-    state={state}
-    variant={variant}
-    disabled={props.disabled}
-  >
-    <StyledSelect {...props} />
-    <StyledCaretSortIcon size={size} />
-  </SelectWrapper>
-);
 
 export const Select = React.forwardRef<React.ElementRef<typeof StyledSelect>, SelectProps>(
   ({ css, size, state, variant, ...props }, forwardedRef) => {


### PR DESCRIPTION
# Description

This PR is not about applying the new Select design which will require us to create a custom Select component or wait for radix to provide a Select primitive.
This PR is about having consistency between the Input and the Select component.

Before:
<img width="1553" alt="Screen Shot 2021-11-05 at 10 10 50" src="https://user-images.githubusercontent.com/1550192/140486425-f18754e7-193a-48e2-b8bb-19273ca13b7b.png">
<img width="1549" alt="Screen Shot 2021-11-05 at 10 10 42" src="https://user-images.githubusercontent.com/1550192/140486427-495f3721-1836-4d1f-b3c5-0806839f08c8.png">



After:
<img width="711" alt="Screen Shot 2021-11-05 at 10 10 14" src="https://user-images.githubusercontent.com/1550192/140486410-f23f9845-9b6a-442b-b224-6bf7abc23e18.png">
<img width="706" alt="Screen Shot 2021-11-05 at 10 10 05" src="https://user-images.githubusercontent.com/1550192/140486413-ce4e9678-99f0-46ae-a301-d32d64280b3d.png">


