### PR TITLE
fix: alpha value on Navigation Item resting state

### DIFF
--- a/components/Navigation/Navigation.tsx
+++ b/components/Navigation/Navigation.tsx
@@ -3,6 +3,18 @@ import { styled, css, VariantProps } from '../../stitches.config';
 import { elevationVariant } from '../Elevation';
 import { Flex } from '../Flex';
 
+const FlexWithOpacity = styled(Flex, {
+  opacity: 0.74,
+
+  variants: {
+    active: {
+      true: {
+        opacity: 1,
+      },
+    },
+  },
+});
+
 const baseNavItemCss = css({
   position: 'relative',
   display: 'flex',
@@ -41,6 +53,10 @@ const baseNavItemCss = css({
     bottom: 0,
     left: 0,
     borderRadius: '$3',
+  },
+
+  [`&:focus > ${FlexWithOpacity}, &:hover > ${FlexWithOpacity}`]: {
+    opacity: 1,
   },
 
   '&:focus': {
@@ -166,8 +182,14 @@ export const NavigationItem = ({
 
   return (
     <NavigationItemWrapper as={as} {...restProps}>
-      {hasStartAdornment && <Flex css={{ pr: '$2', ml: '-$1' }}>{startAdornment}</Flex>}
-      <Flex css={{ flexGrow: 1 }}>{children}</Flex>
+      {hasStartAdornment && (
+        <FlexWithOpacity css={{ pr: '$2', ml: '-$1' }} active={restProps.active}>
+          {startAdornment}
+        </FlexWithOpacity>
+      )}
+      <FlexWithOpacity css={{ flexGrow: 1 }} active={restProps.active}>
+        {children}
+      </FlexWithOpacity>
       {hasEndAdornment && <Flex css={{ pl: '$2', mr: '-$1' }}>{endAdornment}</Flex>}
     </NavigationItemWrapper>
   );


### PR DESCRIPTION
This PR fixes the alpha value for the NavigationItem in resting state (not active, not focused, not hovered).

Current: 
![Screen Shot 2021-11-09 at 12 32 15](https://user-images.githubusercontent.com/38889364/140954248-41329e48-0295-4653-ab5e-343d33bfc5dc.png)

Expected: 
![Screen Shot 2021-11-09 at 12 32 34](https://user-images.githubusercontent.com/38889364/140954259-566927f4-0067-4f2e-bb24-33b89d56ca59.png)


