### PR TITLE
feat: Text component, add inherit variants for fontSize and color

### DIFF
--- a/components/Text/Text.stories.tsx
+++ b/components/Text/Text.stories.tsx
@@ -4,6 +4,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { Text, TextProps, TextVariants } from './Text';
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
 import { Flex } from '../Flex';
+import { Box } from '../Box';
 
 const BaseText = (props: TextProps): JSX.Element => <Text {...props} />;
 const TextForStory = modifyVariantsForStory<TextVariants, TextProps & React.HTMLAttributes<any>>(
@@ -23,8 +24,12 @@ export const Basic = Template.bind({});
 
 Basic.args = {};
 
+const VARIANT_PARENTS = ['$primary', '$purple10'];
+
 export const Variant: ComponentStory<typeof TextForStory> = ({ variant, ...args }) => (
-  <Flex gap={2} direction="column">
+  <Flex align="center" justify="center" css={{
+    height: 100,
+  }} gap={2}>
     <TextForStory {...args} variant="default">
       Default
     </TextForStory>
@@ -57,11 +62,29 @@ export const Transform: ComponentStory<typeof TextForStory> = ({ transform, ...a
     <TextForStory {...args} transform='capitalizeWords'>
       capitalize each word
     </TextForStory>
+    {VARIANT_PARENTS.map((color) => (
+      <Flex direction="column" align="center" justify="center" css={{
+        color,
+        border: '1px dashed currentColor',
+        height: 100,
+        width: 100,
+        position: 'relative'
+      }}>
+        <TextForStory {...args} variant="inherit">
+          Inherit
+        </TextForStory>
+        <Box css={{ position: 'absolute', bottom: 0, fontSize: '$1' }}>
+          Parent color
+        </Box>
+      </Flex>
+    ))}
   </Flex>
 );
 
+const SIZE_PARENTS = ['$4', '$12']
+
 export const Size: ComponentStory<typeof TextForStory> = ({ size, ...args }) => (
-  <>
+  <Flex gap={2} direction="column">
     <TextForStory {...args} size="0">
       Makes Networking Boring
     </TextForStory>
@@ -101,7 +124,21 @@ export const Size: ComponentStory<typeof TextForStory> = ({ size, ...args }) => 
     <TextForStory {...args} size="12">
       Makes Networking Boring
     </TextForStory>
-  </>
+    {SIZE_PARENTS.map((fontSize) => (
+      <Flex css={{
+        fontSize,
+        border: '1px dashed $hiContrast',
+        justifyContent: 'space-between'
+      }}>
+        <TextForStory {...args} size="inherit">
+          Inherit
+        </TextForStory>
+        <Box css={{ color: '$hiContrast' }}>
+          Parent fontSize
+        </Box>
+      </Flex>
+    ))}
+  </Flex>
 );
 
 const Customize: ComponentStory<typeof TextForStory> = (args) => (

--- a/components/Text/Text.stories.tsx
+++ b/components/Text/Text.stories.tsx
@@ -27,9 +27,14 @@ Basic.args = {};
 const VARIANT_PARENTS = ['$primary', '$purple10'];
 
 export const Variant: ComponentStory<typeof TextForStory> = ({ variant, ...args }) => (
-  <Flex align="center" justify="center" css={{
-    height: 100,
-  }} gap={2}>
+  <Flex
+    align="center"
+    justify="center"
+    css={{
+      height: 100,
+    }}
+    gap={2}
+  >
     <TextForStory {...args} variant="default">
       Default
     </TextForStory>
@@ -50,38 +55,39 @@ export const Variant: ComponentStory<typeof TextForStory> = ({ variant, ...args 
 
 export const Transform: ComponentStory<typeof TextForStory> = ({ transform, ...args }) => (
   <Flex gap={2}>
-    <TextForStory {...args} >
-      default text
-    </TextForStory>
-    <TextForStory {...args} transform='uppercase'>
+    <TextForStory {...args}>default text</TextForStory>
+    <TextForStory {...args} transform="uppercase">
       uppercase text
     </TextForStory>
-    <TextForStory {...args} transform='capitalize'>
+    <TextForStory {...args} transform="capitalize">
       capitalize text
     </TextForStory>
-    <TextForStory {...args} transform='capitalizeWords'>
+    <TextForStory {...args} transform="capitalizeWords">
       capitalize each word
     </TextForStory>
     {VARIANT_PARENTS.map((color) => (
-      <Flex direction="column" align="center" justify="center" css={{
-        color,
-        border: '1px dashed currentColor',
-        height: 100,
-        width: 100,
-        position: 'relative'
-      }}>
+      <Flex
+        direction="column"
+        align="center"
+        justify="center"
+        css={{
+          color,
+          border: '1px dashed currentColor',
+          height: 100,
+          width: 100,
+          position: 'relative',
+        }}
+      >
         <TextForStory {...args} variant="inherit">
           Inherit
         </TextForStory>
-        <Box css={{ position: 'absolute', bottom: 0, fontSize: '$1' }}>
-          Parent color
-        </Box>
+        <Box css={{ position: 'absolute', bottom: 0, fontSize: '$1' }}>Parent color</Box>
       </Flex>
     ))}
   </Flex>
 );
 
-const SIZE_PARENTS = ['$4', '$12']
+const SIZE_PARENTS = ['$4', '$12'];
 
 export const Size: ComponentStory<typeof TextForStory> = ({ size, ...args }) => (
   <Flex gap={2} direction="column">
@@ -125,22 +131,24 @@ export const Size: ComponentStory<typeof TextForStory> = ({ size, ...args }) => 
       Makes Networking Boring
     </TextForStory>
     {SIZE_PARENTS.map((fontSize) => (
-      <Flex css={{
-        fontSize,
-        border: '1px dashed $hiContrast',
-        justifyContent: 'space-between'
-      }}>
+      <Flex
+        css={{
+          fontSize,
+          border: '1px dashed $hiContrast',
+          justifyContent: 'space-between',
+        }}
+      >
         <TextForStory {...args} size="inherit">
           Inherit
         </TextForStory>
-        <Box css={{ color: '$hiContrast' }}>
-          Parent fontSize
-        </Box>
+        <Box css={{ color: '$hiContrast' }}>Parent fontSize</Box>
       </Flex>
     ))}
   </Flex>
 );
 
 const Customize: ComponentStory<typeof TextForStory> = (args) => (
-  <TextForStory css={{ fontWeight: '$semiBold' }} {...args}>SemiBold</TextForStory>
+  <TextForStory css={{ fontWeight: '$semiBold' }} {...args}>
+    SemiBold
+  </TextForStory>
 );

--- a/components/Text/Text.tsx
+++ b/components/Text/Text.tsx
@@ -67,11 +67,11 @@ export const Text = styled('span', {
         color: '$textContrast',
       },
       inherit: {
-        color: 'inherit'
+        color: 'inherit',
       },
       invalid: {
-        color: '$textInvalid'
-      }
+        color: '$textInvalid',
+      },
     },
     gradient: {
       true: {
@@ -89,11 +89,11 @@ export const Text = styled('span', {
         display: 'inline-block',
         '&::first-letter': {
           textTransform: 'uppercase',
-        }
+        },
       },
       capitalizeWords: {
         textTransform: 'capitalize',
-      }
+      },
     },
     noWrap: {
       true: {

--- a/components/Text/Text.tsx
+++ b/components/Text/Text.tsx
@@ -49,6 +49,9 @@ export const Text = styled('span', {
       '12': {
         fontSize: '$12',
       },
+      inherit: {
+        fontSize: 'inherit',
+      },
     },
     variant: {
       red: {
@@ -62,6 +65,9 @@ export const Text = styled('span', {
       },
       contrast: {
         color: '$textContrast',
+      },
+      inherit: {
+        color: 'inherit'
       },
       invalid: {
         color: '$textInvalid'


### PR DESCRIPTION
### Description

Text component had no `inherit` feature.

- add `variant="inherit"`
- add `size="inherit"`
- updated variant and size stories to display inherit feature

### Preview

![image](https://user-images.githubusercontent.com/3367393/141971920-e88c3048-fb82-419a-a88c-7b66a0c99ec4.png)
![image](https://user-images.githubusercontent.com/3367393/141971991-888647b0-6e04-45c3-b4d6-98398ba91ce0.png)
