### PR TITLE
fix: Select, before and after, inherit borderRadius

### DIFF
--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -94,6 +94,7 @@ const SelectWrapper = styled('div', {
     position: 'absolute',
     inset: 0,
     pointerEvents: 'none',
+    borderRadius: 'inherit',
   },
   '&::after': {
     boxSizing: 'border-box',
@@ -101,6 +102,7 @@ const SelectWrapper = styled('div', {
     position: 'absolute',
     inset: 0,
     pointerEvents: 'none',
+    borderRadius: 'inherit'
   },
 
   '&:focus-visible': {


### PR DESCRIPTION
### Description

Select had slight visible border-radii when hovered, because pseudo elements applying layers of `background-color` didn't have border-radius aligned with parent.

Apply `border-radius: 'inherit'` on both `::before` and `::after` inside `SelectWrapper`

I show before/after with different colors to make it more visible. Note both `::before` and `::after` require the radius because they are layered one of top of the other.

### Before


![image](https://user-images.githubusercontent.com/3367393/143062558-3c4075e0-0ab7-49a5-a7fc-f5a431a9d20f.png)


### After

![image](https://user-images.githubusercontent.com/3367393/143062734-071cf9bf-2d84-4125-9f26-916b8b713ebc.png)
