### PR TITLE
chore: export elevationVariants

### DIFF
--- a/components/Card/Card.tsx
+++ b/components/Card/Card.tsx
@@ -1,5 +1,5 @@
 import { styled } from '../../stitches.config';
-import { elevationVariant } from '../Elevation/Elevation';
+import { elevationVariants } from '../Elevation/Elevation';
 
 export const Card = styled('div', {
   appearance: 'none',
@@ -33,7 +33,7 @@ export const Card = styled('div', {
   },
 
   variants: {
-    elevation: elevationVariant,
+    elevation: elevationVariants,
     variant: {
       inner: {
         backgroundColor: 'rgba(255,255,255,.07)',

--- a/components/Dialog/Dialog.tsx
+++ b/components/Dialog/Dialog.tsx
@@ -5,7 +5,7 @@ import { Cross1Icon } from '@radix-ui/react-icons';
 import { overlayStyles } from '../Overlay';
 import { IconButton } from '../IconButton';
 import { Card } from '../Card';
-import { elevationVariant } from '../Elevation/Elevation';
+import { elevationVariants } from '../Elevation/Elevation';
 
 type DialogProps = React.ComponentProps<typeof DialogPrimitive.Root> & {
   children: React.ReactNode;
@@ -53,7 +53,7 @@ const StyledContent = styled(DialogPrimitive.Content, Card, {
   },
 
   variants: {
-    elevation: elevationVariant,
+    elevation: elevationVariants,
   },
   defaultVariants: {
     elevation: 5,

--- a/components/Elevation/Elevation.tsx
+++ b/components/Elevation/Elevation.tsx
@@ -2,7 +2,7 @@ import { styled, CSS } from '../../stitches.config';
 
 type ElevationVariant = Record<number, CSS>;
 
-export const elevationVariant: ElevationVariant = {
+export const elevationVariants: ElevationVariant = {
   0: {
     boxShadow: 'none',
   },
@@ -37,7 +37,7 @@ export const Elevation = styled('div', {
   display: 'inline-block',
 
   variants: {
-    variant: elevationVariant,
+    variant: elevationVariants,
   },
   defaultVariants: {
     variant: 1,

--- a/components/Input/Input.tsx
+++ b/components/Input/Input.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { VariantProps } from '@stitches/react';
 import { styled, CSS } from '../../stitches.config';
-import { elevationVariant } from '../Elevation';
+import { elevationVariants } from '../Elevation';
 
 // CONSTANTS
-const FOCUS_SHADOW = elevationVariant[1].boxShadow; // apply elevation $1 when focus
+const FOCUS_SHADOW = elevationVariants[1].boxShadow; // apply elevation $1 when focus
 
 const SMALL_HEIGHT = '$5';
 const MEDIUM_HEIGHT = '$6';

--- a/components/Menu.tsx
+++ b/components/Menu.tsx
@@ -5,7 +5,7 @@ import { styled, css, CSS } from '../stitches.config';
 import { Box } from './Box';
 import { Flex } from './Flex';
 import { panelStyles } from './Panel';
-import { elevationVariant } from './Elevation/Elevation';
+import { elevationVariants } from './Elevation/Elevation';
 
 export const baseItemCss = css({
   display: 'flex',
@@ -46,7 +46,7 @@ export const menuCss = css({
   minWidth: 120,
   py: '$1',
   variants: {
-    elevation: elevationVariant,
+    elevation: elevationVariants,
   },
   defaultVariants: {
     elevation: 2,

--- a/components/Navigation/Navigation.tsx
+++ b/components/Navigation/Navigation.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, ReactNode } from 'react';
 import { styled, css, VariantProps } from '../../stitches.config';
-import { elevationVariant } from '../Elevation';
+import { elevationVariants } from '../Elevation';
 import { Flex } from '../Flex';
 
 const FlexWithOpacity = styled(Flex, {
@@ -133,7 +133,7 @@ export const NavigationDrawer = styled('nav', {
   maxWidth: '240px',
   flexDirection: 'column',
   variants: {
-    elevation: elevationVariant,
+    elevation: elevationVariants,
   },
   defaultVariants: {
     elevation: 1,

--- a/components/Popover/Popover.tsx
+++ b/components/Popover/Popover.tsx
@@ -4,7 +4,7 @@ import * as PopoverPrimitive from '@radix-ui/react-popover';
 import { Box } from '../Box';
 import { panelStyles } from '../Panel';
 import { VariantProps } from '@stitches/react';
-import { elevationVariant } from '../Elevation';
+import { elevationVariants } from '../Elevation';
 
 export type PopoverProps = React.ComponentProps<typeof PopoverPrimitive.Root> & {
   children: React.ReactNode;
@@ -24,7 +24,7 @@ const StyledContent = styled(PopoverPrimitive.Content, panelStyles, {
     outline: 'none',
   },
   variants: {
-    elevation: elevationVariant,
+    elevation: elevationVariants,
   },
   defaultVariants: {
     elevation: 2,

--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { styled, CSS } from '../../stitches.config';
 import { CaretSortIcon } from '@radix-ui/react-icons';
 import { VariantProps } from '@stitches/react';
-import { elevationVariant } from '../Elevation';
+import { elevationVariants } from '../Elevation';
 
 // CONSTANTS
-const FOCUS_SHADOW = elevationVariant[1].boxShadow; // apply elevation $1 when focus
+const FOCUS_SHADOW = elevationVariants[1].boxShadow; // apply elevation $1 when focus
 
 const StyledCaretSortIcon = styled(CaretSortIcon, {
   position: 'absolute',

--- a/components/Switch/Switch.tsx
+++ b/components/Switch/Switch.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { styled, VariantProps, CSS } from '../../stitches.config';
 import * as SwitchPrimitive from '@radix-ui/react-switch';
-import { elevationVariant } from '../Elevation';
+import { elevationVariants } from '../Elevation';
 
 // CONSTANTS
 const THUMB_DIAMETER = 14; // @FIXME: shouldn't this size be part of theme ?
@@ -55,13 +55,13 @@ const StyledSwitch = styled(SwitchPrimitive.Root, {
     '&:hover': {
       cursor: 'pointer',
       [`& ${StyledThumb}`]: {
-        ...elevationVariant[1],
+        ...elevationVariants[1],
       }
     },
   },
   '&:focus': {
     [`& ${StyledThumb}`]: {
-      ...elevationVariant[2],
+      ...elevationVariants[2],
     }
   },
   '&:disabled': {

--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,7 @@ export { Card } from './components/Card';
 export { Checkbox } from './components/Checkbox';
 // export { Code } from './components/Code';
 export { Container } from './components/Container';
-export { Elevation } from './components/Elevation';
+export { Elevation, elevationVariants } from './components/Elevation';
 // export { ControlGroup } from './components/ControlGroup';
 export { FaencyProvider } from './components/FaencyProvider';
 export { Dialog, DialogClose, DialogContent, DialogTrigger } from './components/Dialog';


### PR DESCRIPTION
### Description

exporting `elevationVariants` for external custom components to reuse variants when required.

Using `elevationVariants` or `Elevation` component depends on implementation choices Faency shouldn't make.