### PR TITLE
fix: DocContainer, wrap with FaencyProvider

### DIFF
--- a/.storybook/components/DocContainer.tsx
+++ b/.storybook/components/DocContainer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DocsContainer as BaseContainer } from '@storybook/addon-docs/blocks';
+import { DocsContainer as BaseContainer } from '@storybook/addon-docs';
 import { FaencyProvider } from '../../components/FaencyProvider';
 import { useDarkMode } from 'storybook-dark-mode';
 import { themes } from '@storybook/theming';

--- a/.storybook/components/DocContainer.tsx
+++ b/.storybook/components/DocContainer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { DocsContainer as BaseContainer } from '@storybook/addon-docs/blocks';
+import { FaencyProvider } from '../../components/FaencyProvider';
 import { useDarkMode } from 'storybook-dark-mode';
 import { themes } from '@storybook/theming';
 
@@ -18,7 +19,9 @@ export const DocsContainer = ({ children, context }) => {
         },
       }}
     >
-      {children}
+      <FaencyProvider primaryColor="neon">
+        {children}
+      </FaencyProvider>
     </BaseContainer>
   );
 };


### PR DESCRIPTION
### Description

`FaencyProvider` was not wrapping all stories at once when in doc mode, resulting in `IdProvider` rendering duplicate ids for some components:
- tooltip
- label/input

Docs addon describes a recipe to wrap the whole doc with a provider: https://github.com/storybookjs/storybook/blob/next/addons/docs/docs/recipes.md#overwriting-docs-container

Unfortunately, "canvas" mode doesn't share the same global rendering as "docs" mode. "docs" mode renders each canvas in a global doc, resulting in `FaencyProvider` wrapping duplication. So far, it doesn't seem to be a problem, but I'd like your feedback on that.

Changes:
- solve the previous issue
- don't break behaviour in "canvas" mode
- duplicate `FaencyProvider` wrapping in "docs" mode:

I added a `<div className="toto">` inside the `FaencyProvider` component to highlight its rendering in "docs" mode
![image](https://user-images.githubusercontent.com/3367393/143472818-36610f11-c991-4b69-b542-505543f6d523.png)

I went through all options I found to avoid that wrapping duplication but none seems to work so far. Here's a summary of the documentation I read:
- https://storybook.js.org/docs/react/writing-stories/decorators#global-decorators
- https://storybook.js.org/docs/react/addons/writing-presets#previewmanager-templates
- https://storybook.js.org/docs/react/configure/story-rendering#adding-to-body

### Close issues

Closes #205 

### Preview

#### Before (from another PR)

https://user-images.githubusercontent.com/3367393/143468439-e76c5cb0-d5f8-4b0f-ba47-8435ed0bb339.mov


#### After (without other PR stories :shrug: )

https://user-images.githubusercontent.com/3367393/143468645-a57a822c-35e8-4f9a-8ed2-8cc7487afa6c.mp4


If you want to reproduce the previous use case (tooltips), simply rebase on top of `seedy:feat/update-tooltip-styles`