### PR TITLE
Fix: labels binding in stories

### DIFF
--- a/components/Input/Input.stories.tsx
+++ b/components/Input/Input.stories.tsx
@@ -35,28 +35,29 @@ const Template: ComponentStory<typeof InputForStory> = (args) => <InputForStory 
 export const Basic: ComponentStory<typeof InputForStory> = (args) => (
   <Flex direction="column" gap={2}>
     <Box>
-      <Label>Small</Label>
-      <InputForStory size="small" {...args} />
+      <Label htmlFor="small">Small</Label>
+      <InputForStory id="small" size="small" {...args} />
     </Box>
 
     <Box>
-      <Label>Default</Label>
-      <InputForStory {...args} />
+      <Label htmlFor="default">Default</Label>
+      <InputForStory id="default" {...args} />
     </Box>
 
     <Box>
-      <Label>Large</Label>
-      <InputForStory size="large" {...args} />
+      <Label htmlFor="large">Large</Label>
+      <InputForStory id="large" size="large" {...args} />
     </Box>
 
     <Box>
-      <Label>Ghost</Label>
-      <InputForStory variant="ghost" {...args} />
+      <Label htmlFor="ghost">Ghost</Label>
+      <InputForStory id="ghost" variant="ghost" {...args} />
     </Box>
 
     <Box>
-      <Label>Adornments</Label>
+      <Label htmlFor="adornments">Adornments</Label>
       <InputForStory
+        id="adornments"
         startAdornment={<MagnifyingGlassIcon />}
         endAdornment={<StyledEyeOpenIcon />}
         {...args}
@@ -93,8 +94,8 @@ export const Types: ComponentStory<typeof InputForStory> = ({ type, ...args }) =
   <Flex direction="column" gap={2}>
     {INPUT_TYPES.map((type) => (
       <>
-        <Label key={type}>{type}</Label>
-        <InputForStory {...args} type={type} />
+        <Label htmlFor={type} key={type}>{type}</Label>
+        <InputForStory id={type} {...args} type={type} />
       </>
     ))}
   </Flex>
@@ -115,38 +116,53 @@ ReadOnly.args = { readOnly: true, defaultValue: 'value' };
 
 export const Ghost: ComponentStory<typeof InputForStory> = (args) => (
   <Flex direction="column" gap={2}>
-    <Label>
-      Small
+    <Box>
+      <Label htmlFor="small">
+        Small
+      </Label>
       <InputForStory size="small" {...args} />
-    </Label>
-    <Label>
-      Default
-      <InputForStory {...args} />
-    </Label>
-    <Label>
-      Large
-      <InputForStory size="large" {...args} />
-    </Label>
-    <Label>
-      Invalid
-      <InputForStory state="invalid" {...args} />
-    </Label>
-    <Label>
-      Disabled
-      <InputForStory disabled {...args} />
-    </Label>
-    <Label>
-      ReadOnly
-      <InputForStory readOnly {...args} />
-    </Label>
-    <Label>
-      Adornments
+    </Box>
+    <Box>
+      <Label htmlFor="default">
+        Default
+      </Label>
+      <InputForStory id="default" {...args} />
+    </Box>
+    <Box>
+      <Label htmlFor="large">
+        Large
+      </Label>
+      <InputForStory id="large" size="large" {...args} />
+    </Box>
+    <Box>
+      <Label htmlFor="invalid">
+        Invalid
+      </Label>
+      <InputForStory id="invalid" state="invalid" {...args} />
+    </Box>
+    <Box>
+      <Label htmlFor="disabled">
+        Disabled
+      </Label>
+      <InputForStory id="disabled" disabled {...args} />
+    </Box>
+    <Box>
+      <Label htmlFor="readonly">
+        ReadOnly
+      </Label>
+      <InputForStory id="readonly" readOnly {...args} />
+    </Box>
+    <Box>
+      <Label htmlFor="adornments">
+        Adornments
+      </Label>
       <InputForStory
+        id="adornments"
         startAdornment={<MagnifyingGlassIcon />}
         endAdornment={<StyledEyeOpenIcon />}
         {...args}
       />
-    </Label>
+    </Box>
   </Flex>
 );
 Ghost.args = { defaultValue: 'value', variant: 'ghost' };
@@ -177,51 +193,67 @@ Adornments.argTypes = {
 export const Autofill: ComponentStory<typeof InputForStory> = (args) => (
   <form>
     <Flex direction="column" gap={2}>
-      <Label>
-        Small
-        <InputForStory name="ship-city" autoComplete="shipping locality" size="small" {...args} />
-      </Label>
-      <Label>
-        Default
-        <InputForStory name="ship-organization" autoComplete="shipping organization" {...args} />
-      </Label>
-      <Label>
-        Large
+      <Box>
+        <Label htmlFor="small">
+          Small
+        </Label>
+        <InputForStory id="small" name="ship-city" autoComplete="shipping locality" size="small" {...args} />
+      </Box>
+      <Box>
+        <Label htmlFor="default">
+          Default
+        </Label>
+        <InputForStory id="default" name="ship-organization" autoComplete="shipping organization" {...args} />
+      </Box>
+      <Box>
+        <Label htmlFor="large">
+          Large
+        </Label>
         <InputForStory
+          id="large"
           name="ship-address"
           autoComplete="shipping street-address"
           size="large"
           {...args}
         />
-      </Label>
-      <Label>
-        Ghost
+      </Box>
+      <Box>
+        <Label htmlFor="ghost">
+          Ghost
+        </Label>
         <InputForStory
+          id="ghost"
           name="ship-city"
           autoComplete="shipping locality"
           variant="ghost"
           {...args}
         />
-      </Label>
-      <Label>
-        Invalid
+      </Box>
+      <Box>
+        <Label htmlFor="invalid">
+          Invalid
+        </Label>
         <InputForStory
+          id="invalid"
           name="ship-zip"
           autoComplete="shipping postal-code"
           state="invalid"
           {...args}
         />
-      </Label>
-      <Label>
-        Adornments
+      </Box>
+      <Box>
+        <Label htmlFor="adornments">
+          Adornments
+        </Label>
         <InputForStory
+          id="adornments"
           name="ship-country"
           autoComplete="shipping country"
           startAdornment={<MagnifyingGlassIcon />}
           endAdornment={<StyledEyeOpenIcon />}
           {...args}
         />
-      </Label>
+      </Box>
     </Flex>
   </form>
 );

--- a/components/Input/Input.stories.tsx
+++ b/components/Input/Input.stories.tsx
@@ -9,6 +9,7 @@ import { Flex } from '../Flex';
 import { Label } from '../Label';
 
 import { MagnifyingGlassIcon, EyeOpenIcon } from '@radix-ui/react-icons';
+import ignoreArgType from '../../utils/ignoreArgType';
 
 const StyledEyeOpenIcon = styled(EyeOpenIcon, {
   '@hover': {
@@ -30,34 +31,32 @@ export default {
   argTypes: { onClick: { action: 'clicked' } },
 } as ComponentMeta<typeof InputForStory>;
 
-const Template: ComponentStory<typeof InputForStory> = (args) => <InputForStory {...args} />;
-
-export const Basic: ComponentStory<typeof InputForStory> = (args) => (
+export const Basic: ComponentStory<typeof InputForStory> = ({ id, ...args }) => (
   <Flex direction="column" gap={2}>
     <Box>
-      <Label htmlFor="small">Small</Label>
-      <InputForStory id="small" size="small" {...args} />
+      <Label htmlFor={`${id}-small`}>Small</Label>
+      <InputForStory id={`${id}-small`} size="small" {...args} />
     </Box>
 
     <Box>
-      <Label htmlFor="default">Default</Label>
-      <InputForStory id="default" {...args} />
+      <Label htmlFor={`${id}-default`}>Default</Label>
+      <InputForStory id={`${id}-default`} {...args} />
     </Box>
 
     <Box>
-      <Label htmlFor="large">Large</Label>
-      <InputForStory id="large" size="large" {...args} />
+      <Label htmlFor={`${id}-large`}>Large</Label>
+      <InputForStory id={`${id}-large`} size="large" {...args} />
     </Box>
 
     <Box>
-      <Label htmlFor="ghost">Ghost</Label>
-      <InputForStory id="ghost" variant="ghost" {...args} />
+      <Label htmlFor={`${id}-ghost`}>Ghost</Label>
+      <InputForStory id={`${id}-ghost`} variant="ghost" {...args} />
     </Box>
 
     <Box>
-      <Label htmlFor="adornments">Adornments</Label>
+      <Label htmlFor={`${id}-adornments`}>Adornments</Label>
       <InputForStory
-        id="adornments"
+        id={`${id}-adornments`}
         startAdornment={<MagnifyingGlassIcon />}
         endAdornment={<StyledEyeOpenIcon />}
         {...args}
@@ -66,6 +65,7 @@ export const Basic: ComponentStory<typeof InputForStory> = (args) => (
   </Flex>
 );
 Basic.args = { placeholder: 'placeholder' };
+ignoreArgType('id', Basic);
 
 const INPUT_TYPES = [
   'button',
@@ -94,8 +94,8 @@ export const Types: ComponentStory<typeof InputForStory> = ({ type, ...args }) =
   <Flex direction="column" gap={2}>
     {INPUT_TYPES.map((type) => (
       <>
-        <Label htmlFor={type} key={type}>{type}</Label>
-        <InputForStory id={type} {...args} type={type} />
+        <Label htmlFor={`types-${type}`} key={type}>{type}</Label>
+        <InputForStory id={`types-${type}`} {...args} type={type} />
       </>
     ))}
   </Flex>
@@ -104,60 +104,62 @@ export const Types: ComponentStory<typeof InputForStory> = ({ type, ...args }) =
 Types.args = {};
 
 export const Invalid = Basic.bind({});
-Invalid.args = { state: 'invalid' };
+Invalid.args = { id: 'invalid', state: 'invalid' };
+ignoreArgType('id', Invalid);
 
 export const Disabled = Basic.bind({});
 
-Disabled.args = { disabled: true, defaultValue: 'value' };
+Disabled.args = { id: 'disabled', disabled: true, defaultValue: 'value' };
+ignoreArgType('id', Disabled);
 
 export const ReadOnly = Basic.bind({});
-
-ReadOnly.args = { readOnly: true, defaultValue: 'value' };
+ReadOnly.args = { id: 'readonly', readOnly: true, defaultValue: 'value' };
+ignoreArgType('id', ReadOnly);
 
 export const Ghost: ComponentStory<typeof InputForStory> = (args) => (
   <Flex direction="column" gap={2}>
     <Box>
-      <Label htmlFor="small">
+      <Label htmlFor="ghost-small">
         Small
       </Label>
-      <InputForStory size="small" {...args} />
+      <InputForStory id="ghost-small" size="small" {...args} />
     </Box>
     <Box>
-      <Label htmlFor="default">
+      <Label htmlFor="ghost-default">
         Default
       </Label>
-      <InputForStory id="default" {...args} />
+      <InputForStory id="ghost-default" {...args} />
     </Box>
     <Box>
-      <Label htmlFor="large">
+      <Label htmlFor="ghost-large">
         Large
       </Label>
-      <InputForStory id="large" size="large" {...args} />
+      <InputForStory id="ghost-large" size="large" {...args} />
     </Box>
     <Box>
-      <Label htmlFor="invalid">
+      <Label htmlFor="ghost-invalid">
         Invalid
       </Label>
-      <InputForStory id="invalid" state="invalid" {...args} />
+      <InputForStory id="ghost-invalid" state="invalid" {...args} />
     </Box>
     <Box>
-      <Label htmlFor="disabled">
+      <Label htmlFor="ghost-disabled">
         Disabled
       </Label>
-      <InputForStory id="disabled" disabled {...args} />
+      <InputForStory id="ghost-disabled" disabled {...args} />
     </Box>
     <Box>
-      <Label htmlFor="readonly">
+      <Label htmlFor="ghost-readonly">
         ReadOnly
       </Label>
-      <InputForStory id="readonly" readOnly {...args} />
+      <InputForStory id="ghost-readonly" readOnly {...args} />
     </Box>
     <Box>
-      <Label htmlFor="adornments">
+      <Label htmlFor="ghost-adornments">
         Adornments
       </Label>
       <InputForStory
-        id="adornments"
+        id="ghost-adornments"
         startAdornment={<MagnifyingGlassIcon />}
         endAdornment={<StyledEyeOpenIcon />}
         {...args}
@@ -168,8 +170,8 @@ export const Ghost: ComponentStory<typeof InputForStory> = (args) => (
 Ghost.args = { defaultValue: 'value', variant: 'ghost' };
 
 export const Adornments = Basic.bind({});
-
 Adornments.args = {
+  id: 'adornments',
   startAdornment: <MagnifyingGlassIcon />,
   endAdornment: <StyledEyeOpenIcon />,
 };
@@ -189,28 +191,29 @@ Adornments.argTypes = {
     },
   },
 };
+ignoreArgType('id', Adornments);
 
 export const Autofill: ComponentStory<typeof InputForStory> = (args) => (
   <form>
     <Flex direction="column" gap={2}>
       <Box>
-        <Label htmlFor="small">
+        <Label htmlFor="autofill-small">
           Small
         </Label>
-        <InputForStory id="small" name="ship-city" autoComplete="shipping locality" size="small" {...args} />
+        <InputForStory id="autofill-small" name="ship-city" autoComplete="shipping locality" size="small" {...args} />
       </Box>
       <Box>
-        <Label htmlFor="default">
+        <Label htmlFor="autofill-default">
           Default
         </Label>
-        <InputForStory id="default" name="ship-organization" autoComplete="shipping organization" {...args} />
+        <InputForStory id="autofill-default" name="ship-organization" autoComplete="shipping organization" {...args} />
       </Box>
       <Box>
-        <Label htmlFor="large">
+        <Label htmlFor="autofill-large">
           Large
         </Label>
         <InputForStory
-          id="large"
+          id="autofill-large"
           name="ship-address"
           autoComplete="shipping street-address"
           size="large"
@@ -218,11 +221,11 @@ export const Autofill: ComponentStory<typeof InputForStory> = (args) => (
         />
       </Box>
       <Box>
-        <Label htmlFor="ghost">
+        <Label htmlFor="autofill-ghost">
           Ghost
         </Label>
         <InputForStory
-          id="ghost"
+          id="autofill-ghost"
           name="ship-city"
           autoComplete="shipping locality"
           variant="ghost"
@@ -230,11 +233,11 @@ export const Autofill: ComponentStory<typeof InputForStory> = (args) => (
         />
       </Box>
       <Box>
-        <Label htmlFor="invalid">
+        <Label htmlFor="autofill-invalid">
           Invalid
         </Label>
         <InputForStory
-          id="invalid"
+          id="autofill-invalid"
           name="ship-zip"
           autoComplete="shipping postal-code"
           state="invalid"
@@ -242,11 +245,11 @@ export const Autofill: ComponentStory<typeof InputForStory> = (args) => (
         />
       </Box>
       <Box>
-        <Label htmlFor="adornments">
+        <Label htmlFor="autofill-adornments">
           Adornments
         </Label>
         <InputForStory
-          id="adornments"
+          id="autofill-adornments"
           name="ship-country"
           autoComplete="shipping country"
           startAdornment={<MagnifyingGlassIcon />}

--- a/components/Label/Label.stories.tsx
+++ b/components/Label/Label.stories.tsx
@@ -5,6 +5,7 @@ import { VariantProps } from '@stitches/react';
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
 import { Label } from './Label';
 import { Box } from '../Box';
+import ignoreArgType from '../../utils/ignoreArgType';
 
 type LabelVariants = VariantProps<typeof Label>;
 type LabelProps = LabelVariants & {};
@@ -34,23 +35,25 @@ export const Basic = Template.bind({});
 Basic.args = {
   id: 'basic',
 };
+ignoreArgType('id', Basic);
 
 export const Capitalized = Template.bind({});
 
 Capitalized.args = {
-  id: 'capitalized',
+  id: 'capitalize',
 };
+ignoreArgType('id', Capitalized);
 
 export const Uppercased = Template.bind({});
-
 Uppercased.args = {
-  id: 'uppercased',
+  id: 'uppercase',
   transform: 'uppercase',
 };
+ignoreArgType('id', Uppercased);
 
 export const Error = Template.bind({});
-
 Error.args = {
-  id: 'error',
+  id: 'err',
   variant: 'red',
 };
+ignoreArgType('id', Error);

--- a/components/TextField/TextField.stories.tsx
+++ b/components/TextField/TextField.stories.tsx
@@ -5,6 +5,7 @@ import { Flex } from '../Flex';
 import { TextField, TextFieldProps, TextFieldVariants } from './TextField';
 import { MagnifyingGlassIcon } from '@radix-ui/react-icons';
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
+import ignoreArgType from '../../utils/ignoreArgType';
 
 const BaseTextField = (props: TextFieldProps): JSX.Element => <TextField {...props} />;
 const TextFieldForStory = modifyVariantsForStory<
@@ -22,21 +23,21 @@ const Template: ComponentStory<typeof TextFieldForStory> = (args) => (
   <TextFieldForStory {...args} />
 );
 
-export const Basic: ComponentStory<typeof TextFieldForStory> = (args) => (
+export const Basic: ComponentStory<typeof TextFieldForStory> = ({ id, ...args }) => (
   <Flex direction="column" gap={2}>
-    <TextFieldForStory size="small" id="small" label="small" placeholder="placeholder" {...args} />
-    <TextFieldForStory id="basic" label="basic" placeholder="placeholder" {...args} />
-    <TextFieldForStory size="large" id="large" label="large" placeholder="placeholder" {...args} />
+    <TextFieldForStory size="small" id={`'${id}-small'`} label="small" placeholder="placeholder" {...args} />
+    <TextFieldForStory id={`'${id}-basic'`} label="basic" placeholder="placeholder" {...args} />
+    <TextFieldForStory size="large" id={`'${id}-large'`} label="large" placeholder="placeholder" {...args} />
     <TextFieldForStory
       state="invalid"
-      id="invalid"
+      id={`'${id}-invalid'`}
       label="invalid"
       placeholder="placeholder"
       {...args}
     />
     <TextFieldForStory
       startAdornment={<MagnifyingGlassIcon />}
-      id="search"
+      id={`'${id}-search'`}
       label="search"
       placeholder="Search..."
       {...args}
@@ -44,23 +45,31 @@ export const Basic: ComponentStory<typeof TextFieldForStory> = (args) => (
   </Flex>
 );
 
-export const PasswordType = Template.bind({});
+Basic.args = {
+  id: 'basic'
+}
+ignoreArgType('id', Basic)
 
-PasswordType.args = { type: 'password', id: 'password-type', label: 'password' };
+export const PasswordType = Template.bind({});
+PasswordType.args = { type: 'password', id: 'passwordtype', label: 'password' };
+ignoreArgType('id', PasswordType);
 
 export const Clearable = Basic.bind({});
-Clearable.args = { clearable: true };
+Clearable.args = { id: 'clearable', clearable: true };
+ignoreArgType('id', Clearable);
 
 export const Disabled = Basic.bind({});
-Disabled.args = { disabled: true };
+Disabled.args = { id: 'disabled', disabled: true };
+ignoreArgType('id', Disabled);
 
 export const ReadOnly = Basic.bind({});
-ReadOnly.args = { readOnly: true };
+ReadOnly.args = { id: 'readonly', readOnly: true };
+ignoreArgType('id', ReadOnly);
 
-export const Display: ComponentStory<typeof TextFieldForStory> = (args) => (
+export const Display: ComponentStory<typeof TextFieldForStory> = ({ id, ...args }) => (
   <Flex direction="column" gap={2}>
     <TextFieldForStory
-      id="disabled"
+      id={`${id}-disabled`}
       label="disabled"
       placeholder="placeholder"
       value="disabled"
@@ -68,7 +77,7 @@ export const Display: ComponentStory<typeof TextFieldForStory> = (args) => (
       {...args}
     />
     <TextFieldForStory
-      id="readOnly"
+      id={`${id}-readOnly`}
       label="readOnly"
       placeholder="placeholder"
       value="readOnly"
@@ -78,7 +87,14 @@ export const Display: ComponentStory<typeof TextFieldForStory> = (args) => (
   </Flex>
 );
 
+Display.args = {
+  id: 'display',
+}
+ignoreArgType('id', Display)
+
 export const DisplayClearable = Display.bind({});
 DisplayClearable.args = {
+  id: 'displayclearable',
   clearable: true,
 };
+ignoreArgType('id', DisplayClearable);

--- a/utils/ignoreArgType.ts
+++ b/utils/ignoreArgType.ts
@@ -1,0 +1,13 @@
+const ignoreArgType = (key, Story) => {
+  Story.argTypes = {
+    ...(Story?.argTypes || {}),
+    [key]: {
+      table: {
+        disable: true
+      }
+    }
+  };
+  return Story;
+};
+
+export default ignoreArgType


### PR DESCRIPTION
### Description

Inputs and their Labels are now binded through `htmlFor` + `id` combinations. Hence, they require unique ids inside both "canvas" and "docs" modes.

### Close issue

Closes #210

### Changes

Rework `Input` and `Label` bindings in all related stories:
- Input
- Label
- TextField 

Added a helper `ignoreArgType`  to shorten hiding the `id` arg I had to pass to template stories and their duplicates.

### Misc

:warning: I noticed that each story title held an `id` which may conflict with ids we set inside stories.
![image](https://user-images.githubusercontent.com/3367393/143486030-2e62c24a-5c55-4db6-accf-4dc93db0fcb0.png)

There's an issue calling for improvements on that subject: #208 