### PR TITLE
Fix: dialog overlay broken

### DIFF
--- a/components/Overlay.tsx
+++ b/components/Overlay.tsx
@@ -1,7 +1,7 @@
 import { styled, CSS } from '../stitches.config';
 
 export const overlayStyles: CSS = {
-  backgroundColor: 'hsla(0, 0, 0, 0.7)',
+  backgroundColor: 'hsla(0, 0%, 0%, 0.7)',
 };
 
 export const Overlay = styled('div', overlayStyles);


### PR DESCRIPTION
### Description

Dialog overlay was not applying any background color.

Cause: wrong syntax for hsla computation

### Closes

Closes #181 

### Preview

#### Before



https://user-images.githubusercontent.com/3367393/144429413-62802cb7-e37a-48ee-a5c1-d634967a19ab.mp4

#### After

https://user-images.githubusercontent.com/3367393/144429428-0b19bd7d-9aee-4bff-8cf5-c60764daaca7.mp4



