### PR TITLE
fix: sheet update primitive integration

### DIFF
--- a/components/Sheet.tsx
+++ b/components/Sheet.tsx
@@ -123,8 +123,10 @@ export const SheetContent = React.forwardRef<
 >(({ children, ...props }, forwardedRef) => (
   <StyledContent {...props} ref={forwardedRef}>
     {children}
-    <DialogPrimitive.Close as={StyledCloseButton} variant="ghost">
-      <Cross1Icon />
+    <DialogPrimitive.Close asChild>
+      <StyledCloseButton ghost>
+        <Cross1Icon />
+      </StyledCloseButton>
     </DialogPrimitive.Close>
   </StyledContent>
 ));


### PR DESCRIPTION
### Description

Sheet component primitive integration was not up to date:
- DialogPrimitive.Close should wrap child and have `asChild`
- IconButton prop `ghost` properly binded

I don't know the point of this component, so far. Should we delete it?