### PR TITLE
fix: Dialog story, proper use of Dialog and DialogTrigger

### DIFF
--- a/components/Dialog/Dialog.stories.tsx
+++ b/components/Dialog/Dialog.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import { Dialog, DialogContent } from './Dialog';
+import { Dialog, DialogContent, DialogTrigger, DialogClose } from './Dialog';
 import { Text } from '../Text';
 import { useState } from 'react';
 import { Button } from '../Button';
@@ -39,8 +39,10 @@ export const Basic: ComponentStory<any> = (args) => {
   const [open, setOpen] = useState(false);
 
   return (
-    <>
-      <Button onClick={() => setOpen(true)}>Open dialog</Button>
+    <Dialog open={open} onOpenChange={(isOpen) => setOpen(isOpen)}>
+      <DialogTrigger asChild>
+        <Button onClick={() => setOpen(true)}>Open dialog</Button>
+      </DialogTrigger>
 
       <Box>
         {[...Array(10)].map((_, i) => (
@@ -55,11 +57,9 @@ export const Basic: ComponentStory<any> = (args) => {
         ))}
       </Box>
 
-      <Dialog open={open} onOpenChange={(isOpen) => setOpen(isOpen)}>
-        <DialogContent>
-          <Content />
-        </DialogContent>
-      </Dialog>
-    </>
+      <DialogContent>
+        <Content />
+      </DialogContent>
+    </Dialog>
   );
 };


### PR DESCRIPTION
### Description

In Dialog story, example was not properly using Dialog.

I updated the story, based on radix doc: https://www.radix-ui.com/docs/primitives/components/dialog#abstract-the-overlay-and-the-close-button

Consequences: focus is restored to the trigger button when dialog is closed

Test for yourself on the story