### PR TITLE
feat: visuallyHidden + table accessible examples

### DIFF
--- a/components/Table/Table.stories.tsx
+++ b/components/Table/Table.stories.tsx
@@ -1,9 +1,12 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import React from 'react';
-import { Table, TableProps, TableVariants, Tbody, Td, Th, Thead, Tr } from './Table';
+import { Table, TableProps, TableVariants, Tbody, Td, Th, Thead, Tr, Tfoot, Caption } from './Table';
 import { Badge } from '../Badge';
 import { Card } from '../Card';
+import { Flex } from '../Flex';
+import { Heading } from '../Heading';
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
+import { VisuallyHidden } from '../VisuallyHidden';
 
 const BaseTable = (props: TableProps): JSX.Element => <Table {...props} />;
 const TableForStory = modifyVariantsForStory<TableVariants, TableProps>(BaseTable);
@@ -190,3 +193,215 @@ export const Interactive: ComponentStory<any> = (args) => (
 Interactive.args = {
   interactive: true,
 };
+
+
+export const WithFooter: ComponentStory<any> = (args) => (
+  <Card>
+    <TableForStory {...args}>
+      <Thead>
+        <Th>Firstname</Th>
+        <Th>Lastname</Th>
+        <Th>Status</Th>
+        <Th>Role</Th>
+      </Thead>
+      <Tbody>
+        <Tr>
+          <Td>John</Td>
+          <Td>Doe</Td>
+          <Td>
+            <Badge variant="green">Connected</Badge>
+          </Td>
+          <Td>Developer</Td>
+        </Tr>
+        <Tr>
+          <Td>Johny</Td>
+          <Td>Depp</Td>
+          <Td>
+            <Badge variant="orange">AFK</Badge>
+          </Td>
+          <Td>Actor</Td>
+        </Tr>
+        <Tr>
+          <Td>Natalie</Td>
+          <Td>Portman</Td>
+          <Td>
+            <Badge variant="green">Connected</Badge>
+          </Td>
+          <Td>Actor</Td>
+        </Tr>
+        <Tr>
+          <Td>Luke</Td>
+          <Td>Skywalker</Td>
+          <Td>
+            <Badge variant="red">Disconnected</Badge>
+          </Td>
+          <Td>Star wars</Td>
+        </Tr>
+      </Tbody>
+      <Tfoot>
+        <Tr>
+          <Td colSpan={4}>
+            Footer information
+          </Td>
+        </Tr>
+      </Tfoot>
+    </TableForStory>
+  </Card>
+)
+
+export const WithCaption: ComponentStory<any> = (args) => {
+  const id = "described-heading"
+  const title = 'Title not child of table'
+  return (
+    <>
+      <Flex direction="column" gap="4">
+        <Card>
+          <TableForStory {...args}>
+            <Caption>Caption child of table</Caption>
+            <Thead>
+              <Th>Firstname</Th>
+              <Th>Lastname</Th>
+              <Th>Status</Th>
+              <Th>Role</Th>
+            </Thead>
+            <Tbody>
+              <Tr>
+                <Td>John</Td>
+                <Td>Doe</Td>
+                <Td>
+                  <Badge variant="green">Connected</Badge>
+                </Td>
+                <Td>Developer</Td>
+              </Tr>
+              <Tr>
+                <Td>Johny</Td>
+                <Td>Depp</Td>
+                <Td>
+                  <Badge variant="orange">AFK</Badge>
+                </Td>
+                <Td>Actor</Td>
+              </Tr>
+              <Tr>
+                <Td>Natalie</Td>
+                <Td>Portman</Td>
+                <Td>
+                  <Badge variant="green">Connected</Badge>
+                </Td>
+                <Td>Actor</Td>
+              </Tr>
+              <Tr>
+                <Td>Luke</Td>
+                <Td>Skywalker</Td>
+                <Td>
+                  <Badge variant="red">Disconnected</Badge>
+                </Td>
+                <Td>Star wars</Td>
+              </Tr>
+            </Tbody>
+          </TableForStory>
+        </Card>
+        <div>
+          <Heading size="4" as="h1">
+            {title}
+          </Heading>
+          <Card>
+            <TableForStory {...args}>
+              <VisuallyHidden asChild>
+                <Caption>{title}</Caption>
+              </VisuallyHidden>
+              <Thead>
+                <Th>Firstname</Th>
+                <Th>Lastname</Th>
+                <Th>Status</Th>
+                <Th>Role</Th>
+              </Thead>
+              <Tbody>
+                <Tr>
+                  <Td>John</Td>
+                  <Td>Doe</Td>
+                  <Td>
+                    <Badge variant="green">Connected</Badge>
+                  </Td>
+                  <Td>Developer</Td>
+                </Tr>
+                <Tr>
+                  <Td>Johny</Td>
+                  <Td>Depp</Td>
+                  <Td>
+                    <Badge variant="orange">AFK</Badge>
+                  </Td>
+                  <Td>Actor</Td>
+                </Tr>
+                <Tr>
+                  <Td>Natalie</Td>
+                  <Td>Portman</Td>
+                  <Td>
+                    <Badge variant="green">Connected</Badge>
+                  </Td>
+                  <Td>Actor</Td>
+                </Tr>
+                <Tr>
+                  <Td>Luke</Td>
+                  <Td>Skywalker</Td>
+                  <Td>
+                    <Badge variant="red">Disconnected</Badge>
+                  </Td>
+                  <Td>Star wars</Td>
+                </Tr>
+              </Tbody>
+            </TableForStory>
+          </Card>
+        </div>
+        <div>
+          <Heading id={id} size="4" as="h1">
+            {title}
+          </Heading>
+          <Card>
+            <TableForStory aria-describedby={id} {...args}>
+              <Thead>
+                <Th>Firstname</Th>
+                <Th>Lastname</Th>
+                <Th>Status</Th>
+                <Th>Role</Th>
+              </Thead>
+              <Tbody>
+                <Tr>
+                  <Td>John</Td>
+                  <Td>Doe</Td>
+                  <Td>
+                    <Badge variant="green">Connected</Badge>
+                  </Td>
+                  <Td>Developer</Td>
+                </Tr>
+                <Tr>
+                  <Td>Johny</Td>
+                  <Td>Depp</Td>
+                  <Td>
+                    <Badge variant="orange">AFK</Badge>
+                  </Td>
+                  <Td>Actor</Td>
+                </Tr>
+                <Tr>
+                  <Td>Natalie</Td>
+                  <Td>Portman</Td>
+                  <Td>
+                    <Badge variant="green">Connected</Badge>
+                  </Td>
+                  <Td>Actor</Td>
+                </Tr>
+                <Tr>
+                  <Td>Luke</Td>
+                  <Td>Skywalker</Td>
+                  <Td>
+                    <Badge variant="red">Disconnected</Badge>
+                  </Td>
+                  <Td>Star wars</Td>
+                </Tr>
+              </Tbody>
+            </TableForStory>
+          </Card>
+        </div>
+      </Flex>
+    </>
+  )
+}

--- a/components/VisuallyHidden/VisuallyHidden.stories.tsx
+++ b/components/VisuallyHidden/VisuallyHidden.stories.tsx
@@ -1,0 +1,59 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import React from 'react';
+import { VisuallyHidden } from './VisuallyHidden';
+import { Table, Caption } from '../Table'
+import { Card } from '../Card';
+import { GearIcon } from '@radix-ui/react-icons';
+import { styled } from '../../stitches.config';
+
+const FlexButton = styled('button', {
+  m: 0,
+  p: 0,
+  color: '$hiContrast',
+  border: '1px dashed $hiContrast',
+  display: 'flex',
+  background: 'none'
+});
+
+const ContrastDiv = styled('div', {
+  color: '$hiContrast',
+});
+
+export default {
+  title: 'Components/VisuallyHidden',
+  component: VisuallyHidden,
+} as ComponentMeta<typeof VisuallyHidden>;
+
+export const Basic: ComponentStory<typeof VisuallyHidden> = (args) => (
+  <ContrastDiv>
+    <VisuallyHidden {...args}>Hidden visually</VisuallyHidden>
+  </ContrastDiv>
+);
+
+export const HiddenButtonText: ComponentStory<typeof VisuallyHidden> = (args) => (
+  <FlexButton>
+    <GearIcon />
+    <VisuallyHidden {...args}>Settings</VisuallyHidden>
+  </FlexButton>
+)
+
+export const AsChild: ComponentStory<typeof VisuallyHidden> = (args) => (
+  <ContrastDiv>
+    <Card>
+      <Table css={{ minHeight: 50, border: '1px dashed $hiContrast' }}>
+        <VisuallyHidden {...args}>
+          <Caption>Hidden visually</Caption>
+        </VisuallyHidden>
+      </Table>
+    </Card>
+    <Card>
+      <Table css={{ minHeight: 50, border: '1px dashed $hiContrast' }}>
+        <Caption>Not hidden visually</Caption>
+      </Table>
+    </Card>
+  </ContrastDiv>
+)
+
+AsChild.args = {
+  asChild: true,
+}

--- a/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/components/VisuallyHidden/VisuallyHidden.tsx
@@ -1,0 +1,3 @@
+import * as VisuallyHiddenPrimitive from '@radix-ui/react-visually-hidden';
+
+export const VisuallyHidden = VisuallyHiddenPrimitive.Root;

--- a/components/VisuallyHidden/index.tsx
+++ b/components/VisuallyHidden/index.tsx
@@ -1,0 +1,1 @@
+export * from './VisuallyHidden'

--- a/index.ts
+++ b/index.ts
@@ -49,6 +49,7 @@ export { Caption as AriaCaption, Tbody as AriaTbody, Tfoot as AriaTfoot, Tr as A
 export { Caption, Tbody, Tfoot, Tr, Th, Td, Thead, Table } from './components/Table';
 export { Text } from './components/Text';
 export { Tooltip } from './components/Tooltip';
+export { VisuallyHidden } from './components/VisuallyHidden';
 
 // Stitches
 export {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@radix-ui/react-toggle": "0.1.1",
     "@radix-ui/react-tooltip": "0.1.1",
     "@radix-ui/react-use-layout-effect": "^0.1.0",
+    "@radix-ui/react-visually-hidden": "0.1.3",
     "@stitches/react": "1.2.6",
     "lodash.merge": "^4.6.2",
     "tinycolor2": "^1.4.2",


### PR DESCRIPTION
## Description

Add VisuallyHidden primitive

Give accessible examples of tables with a title.
3 Options:
1. Display caption and style it
2. Display a title not child of table + duplicate title with a visually hidden caption
3. Display a title not child of table + link through `aria-describedby` attribute on table 

Option 2 is recommended over Option 3 [here](https://www.w3.org/WAI/tutorials/tables/caption-summary).

See https://www.w3.org/WAI/tutorials/tables/caption-summary

## Dependency changes

<!--
If there was changes in the dependencies, please mention them here. Added/Updated/Removed dependencies.
For added dependencies, it's nice to have a description of why it was needed.
-->

| Dependency | Version        | State   |
| ---------- | -------------- | ------- |
| `@radix-ui/react-visually-hidden`       | 0.1.3          | Added   |


Added [`@radix-ui//react-visually-hidden`](https://www.radix-ui.com/docs/primitives/utilities/visually-hidden) to allow hiding some accessibility-driven dom nodes which are not intended to impact UI.

Best option for an accessible table is to have a visually hidden caption duplicating the title.

## Good PR checkboxes

- [x] Change has been tested
- [ ] Added/Updated tests
- [x] Added/Updated documentation
- [ ] Content is fluid (well displayed in 768px screens)
- [x] Labels are set
- [x] Project is linked
