### PR TITLE
fix: [Select] selected option overflows, better caret position

### DIFF
--- a/components/Select/Select.stories.tsx
+++ b/components/Select/Select.stories.tsx
@@ -44,3 +44,25 @@ State.args = { state: 'invalid' };
 export const Disabled = Template.bind({});
 
 Disabled.args = { disabled: true, defaultValue: 'option3' };
+
+export const Overflow: ComponentStory<typeof SelectForStory> = ({ width, ...args }) => (
+  <SelectForStory css={{ width }} {...args}>
+    <option value="option1">Too long option, I have to cut</option>
+    <option value="option2">Option 2</option>
+    <option value="option3">Option 3</option>
+    <option value="option4">Option 4</option>
+    <option value="option5">Option 5</option>
+  </SelectForStory>
+);
+
+Overflow.args = { width: 100, defaultValue: 'option1', size: 'medium' };
+
+Overflow.argTypes = {
+  size: {
+    control: 'inline-radio',
+    options: ['small', 'medium', 'large']
+  },
+  width: {
+    control: 'number'
+  }
+}

--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -6,6 +6,7 @@ import { elevationVariants } from '../Elevation';
 
 // CONSTANTS
 const FOCUS_SHADOW = elevationVariants[1].boxShadow; // apply elevation $1 when focus
+const CARET_WIDTH = '15px';
 
 const StyledCaretSortIcon = styled(CaretSortIcon, {
   position: 'absolute',
@@ -59,6 +60,9 @@ const StyledSelect = styled('select', {
   pl: '$1',
   pr: '$3',
   lineHeight: '25px',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
 
   '& option': {
     color: 'black',
@@ -154,10 +158,11 @@ const SelectWrapper = styled('div', {
           fontSize: '$1',
         },
         [`& ${StyledSelect}`]: {
-          px: '$2',
+          pl: '$2',
+          pr: `calc($2 + ${CARET_WIDTH})`
         },
         [`& ${StyledCaretSortIcon}`]: {
-          right: '$2',
+          right: 'calc($2 / 2)',
         },
       },
       medium: {
@@ -169,10 +174,11 @@ const SelectWrapper = styled('div', {
           fontSize: '$3',
         },
         [`& ${StyledSelect}`]: {
-          px: '$3',
+          pl: '$3',
+          pr: `calc($3 + ${CARET_WIDTH})`,
         },
         [`& ${StyledCaretSortIcon}`]: {
-          right: '$3',
+          right: 'calc($3 / 2)',
         },
       },
       large: {
@@ -184,10 +190,11 @@ const SelectWrapper = styled('div', {
           fontSize: '$3',
         },
         [`& ${StyledSelect}`]: {
-          px: '$3',
+          pl: '$3',
+          pr: `calc($3 + ${CARET_WIDTH})`,
         },
         [`& ${StyledCaretSortIcon}`]: {
-          right: '$3',
+          right: 'calc($3 / 2)',
         },
       },
     },


### PR DESCRIPTION
## Description

Closes #239 

Apply to select:
```
overflow: 'hidden',
textOverflow: 'ellipsis',
whiteSpace: 'nowrap',
```

Better position for Caret with better spacing inside select.

Added a specific story for Select: `Overflow`


## Test

Tested on Chrome + Firefox

## Preview

https://user-images.githubusercontent.com/3367393/147371779-645adc1c-8c74-403b-94af-00eba54412c6.mp4
