### PR TITLE
Fix: label all letters capitalized

### DIFF
--- a/components/Label/Label.stories.tsx
+++ b/components/Label/Label.stories.tsx
@@ -24,7 +24,7 @@ export default {
 const Template: ComponentStory<typeof LabelForStory> = ({ id, ...args }) => (
   <Box>
     <LabelForStory htmlFor={id} css={{ mr: '$2' }} {...args}>
-      Email
+      Email field
     </LabelForStory>
     <input id={id} name="email" type="email" />
   </Box>
@@ -43,6 +43,16 @@ Capitalized.args = {
   id: 'capitalize',
 };
 ignoreArgType('id', Capitalized);
+
+export const CapitalizedWords = Template.bind({});
+
+CapitalizedWords.args = {
+  id: 'capitalize-words',
+  transform: 'capitalizeWords'
+};
+ignoreArgType('id', CapitalizedWords);
+
+
 
 export const Uppercased = Template.bind({});
 Uppercased.args = {

--- a/components/Text/Text.stories.tsx
+++ b/components/Text/Text.stories.tsx
@@ -40,6 +40,23 @@ export const Variant: ComponentStory<typeof TextForStory> = ({ variant, ...args 
   </Flex>
 );
 
+export const Transform: ComponentStory<typeof TextForStory> = ({ transform, ...args }) => (
+  <Flex gap={2}>
+    <TextForStory {...args} >
+      default text
+    </TextForStory>
+    <TextForStory {...args} transform='uppercase'>
+      uppercase text
+    </TextForStory>
+    <TextForStory {...args} transform='capitalize'>
+      capitalize text
+    </TextForStory>
+    <TextForStory {...args} transform='capitalizeWords'>
+      capitalize each word
+    </TextForStory>
+  </Flex>
+);
+
 export const Size: ComponentStory<typeof TextForStory> = ({ size, ...args }) => (
   <>
     <TextForStory {...args} size="0">

--- a/components/Text/Text.tsx
+++ b/components/Text/Text.tsx
@@ -77,6 +77,7 @@ export const Text = styled('span', {
       },
       capitalize: {
         // WARNING: this will only work with block elements (display block/inline-block)
+        // @see https://developer.mozilla.org/en-US/docs/Web/CSS/::first-letter
         '&::first-letter': {
           textTransform: 'uppercase',
         }

--- a/components/Text/Text.tsx
+++ b/components/Text/Text.tsx
@@ -76,8 +76,14 @@ export const Text = styled('span', {
         textTransform: 'uppercase',
       },
       capitalize: {
-        textTransform: 'capitalize',
+        // WARNING: this will only work with block elements (display block/inline-block)
+        '&::first-letter': {
+          textTransform: 'uppercase',
+        }
       },
+      capitalizeWords: {
+        textTransform: 'capitalize',
+      }
     },
     noWrap: {
       true: {

--- a/components/Text/Text.tsx
+++ b/components/Text/Text.tsx
@@ -7,7 +7,7 @@ export const Text = styled('span', {
   margin: '0',
   fontFamily: '$rubik',
   fontVariantNumeric: 'tabular-nums',
-  display: 'block',
+  display: 'inline-block',
 
   variants: {
     size: {
@@ -78,6 +78,7 @@ export const Text = styled('span', {
       capitalize: {
         // WARNING: this will only work with block elements (display block/inline-block)
         // @see https://developer.mozilla.org/en-US/docs/Web/CSS/::first-letter
+        display: 'inline-block',
         '&::first-letter': {
           textTransform: 'uppercase',
         }


### PR DESCRIPTION
# Description

Closes #242 

`transform="capitalize"` now capitalizes only first letter.

Adds `transform="capitalizeWords"` in case previous behaviour may be of any use.

Updates stories for `Text` and `Label`

# Warnings

:warning: Added as comment in `Text`: this will only work with block elements (display block/inline-block)

Overriding `Text` or `Label` display might conflict with this variant

[source](https://developer.mozilla.org/en-US/docs/Web/CSS/::first-letter)