### PR TITLE
Fix: label capitalize breaking th layout

### DIFF
--- a/components/Table/Table.stories.tsx
+++ b/components/Table/Table.stories.tsx
@@ -66,7 +66,13 @@ Basic.args = {
 Basic.argTypes = {
   transform: {
     control: 'inline-radio',
-    options: ['capitalize', 'capitalizeWords', 'uppercase', '']
+    options: ['capitalize', 'capitalizeWords', 'uppercase', 'none'],
+    mapping: {
+      capitalize: 'capitalize',
+      capitalizeWords: 'capitalizeWords',
+      uppercase: 'uppercase',
+      none: '',
+    }
   },
 };
 

--- a/components/Table/Table.stories.tsx
+++ b/components/Table/Table.stories.tsx
@@ -13,14 +13,14 @@ export default {
   component: TableForStory,
 } as ComponentMeta<typeof TableForStory>;
 
-export const Basic: ComponentStory<typeof TableForStory> = (args) => (
+export const Basic: ComponentStory<any> = ({ transform, ...args }) => (
   <Card>
     <TableForStory {...args}>
       <Thead>
-        <Th>Firstname</Th>
-        <Th>Lastname</Th>
-        <Th>Status</Th>
-        <Th>Role</Th>
+        <Th transform={transform}>first name</Th>
+        <Th transform={transform}>last name</Th>
+        <Th transform={transform}>Status</Th>
+        <Th transform={transform}>Role</Th>
       </Thead>
       <Tbody>
         <Tr>
@@ -59,6 +59,16 @@ export const Basic: ComponentStory<typeof TableForStory> = (args) => (
     </TableForStory>
   </Card>
 );
+
+Basic.args = {
+  transform: 'capitalize',
+};
+Basic.argTypes = {
+  transform: {
+    control: 'inline-radio',
+    options: ['capitalize', 'capitalizeWords', 'uppercase', '']
+  },
+};
 
 export const Alignment: ComponentStory<any> = (args) => (
   <Card>

--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -64,7 +64,7 @@ export const Th = styled('th', Label, {
     },
     transform: {
       capitalize: {
-        display: 'table-cell',
+        display: 'table-cell', // revert Label enforced value
       }
     }
   },

--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -62,6 +62,11 @@ export const Th = styled('th', Label, {
         textAlign: 'end',
       },
     },
+    transform: {
+      capitalize: {
+        display: 'table-cell',
+      }
+    }
   },
   defaultVariants: {
     align: 'start',


### PR DESCRIPTION
# Description

`Th` extends `Label` styles and variants.

When `transform='capitalize'` default variant is applied to `Th`, style `display: 'inline-block'` takes precedence.
It breaks table layout.

I reset `display: 'table-cell'` from inside `Th` to correct this behaviour.

# Questions

What would you prefer?
1. Removing this enforced display value from `Text`, which could lead to unexpected bugs with `capitalize` when display does not match a block level, but removes the extra logic inside `Th`
2. Doing as I proposed