### PR TITLE
feat: radio accordion

### DIFF
--- a/components/Accordion/Accordion.tsx
+++ b/components/Accordion/Accordion.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
-import { keyframes, styled } from '../../stitches.config';
+import { keyframes, styled, VariantProps } from '../../stitches.config';
 import { elevationVariants } from '../Elevation';
 import { ChevronRightIcon } from '@radix-ui/react-icons';
-import { VariantProps } from '@stitches/react';
 
 const open = keyframes({
   from: { height: 0 },
@@ -35,13 +34,13 @@ const StyledAccordionItem = styled(AccordionPrimitive.Item, {
   boxShadow: '0 1px 0 0 $colors$divider',
 })
 
-const StyledAccordionHeader = styled(AccordionPrimitive.Header, {
+export const StyledAccordionHeader = styled(AccordionPrimitive.Header, {
   all: 'unset',
   display: 'flex',
   borderRadius: 'inherit',
 });
 
-const StyledAccordionTrigger = styled(AccordionPrimitive.Trigger, {
+export const StyledAccordionTrigger = styled(AccordionPrimitive.Trigger, {
   all: 'unset',
   borderRadius: 'inherit',
   fontFamily: 'inherit',

--- a/components/Radio/Radio.tsx
+++ b/components/Radio/Radio.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
 import { styled, CSS, VariantProps } from '../../stitches.config';
-import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
 
 export const RadioGroup = styled(RadioGroupPrimitive.Root, {
   display: 'flex',
 });
 
-const StyledIndicator = styled(RadioGroupPrimitive.Indicator, {
+export const INDICATOR_BASE_STYLES = {
   alignItems: 'center',
   display: 'flex',
   height: '100%',
@@ -19,12 +18,14 @@ const StyledIndicator = styled(RadioGroupPrimitive.Indicator, {
     display: 'block',
     width: '8px',
     height: '8px',
-    borderRadius: '50%',
+    borderRadius: '$round',
     backgroundColor: '$radioIndicator',
   },
-});
+};
 
-const StyledRadio = styled(RadioGroupPrimitive.Item, {
+const StyledIndicator = styled(RadioGroupPrimitive.Indicator, INDICATOR_BASE_STYLES);
+
+export const RADIO_BASE_STYLES = {
   all: 'unset',
   boxSizing: 'border-box',
   userSelect: 'none',
@@ -49,6 +50,8 @@ const StyledRadio = styled(RadioGroupPrimitive.Item, {
   color: '$hiContrast',
   boxShadow: 'inset 0 0 0 1px $colors$radioBorder',
   overflow: 'hidden',
+}
+const StyledRadio = styled(RadioGroupPrimitive.Item, RADIO_BASE_STYLES, {
   '@hover': {
     '&:hover': {
       boxShadow: 'inset 0 0 0 1px $colors$radioHoverBorder',

--- a/components/RadioAccordion/RadioAccordion.stories.tsx
+++ b/components/RadioAccordion/RadioAccordion.stories.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { RadioAccordionRoot, RadioAccordionItem, RadioAccordionContent, RadioAccordionTrigger } from './RadioAccordion';
+import { Box } from '../Box';
+
+export default {
+  title: 'Components/RadioAccordion',
+  component: RadioAccordionRoot,
+} as ComponentMeta<typeof RadioAccordionRoot>;
+
+export const Basic: ComponentStory<typeof RadioAccordionRoot> = (args) => (
+  <Box css={{ width: 300 }}>
+    <RadioAccordionRoot {...args}>
+      <RadioAccordionItem value="item-1">
+        <RadioAccordionTrigger >Item1 Trigger</RadioAccordionTrigger>
+        <RadioAccordionContent >Item1 Content</RadioAccordionContent>
+      </RadioAccordionItem>
+      <RadioAccordionItem value="item-2">
+        <RadioAccordionTrigger >Item2 Trigger</RadioAccordionTrigger>
+        <RadioAccordionContent >Item2 Content</RadioAccordionContent>
+      </RadioAccordionItem>
+      <RadioAccordionItem value="item-3">
+        <RadioAccordionTrigger >Item3 Trigger</RadioAccordionTrigger>
+        <RadioAccordionContent >Item3 Content</RadioAccordionContent>
+      </RadioAccordionItem>
+    </RadioAccordionRoot>
+  </Box>
+);

--- a/components/RadioAccordion/RadioAccordion.tsx
+++ b/components/RadioAccordion/RadioAccordion.tsx
@@ -33,17 +33,28 @@ const StyledIndicator = styled('div', INDICATOR_BASE_STYLES, {
   },
 });
 
+const StyledRadioAccordionTrigger = styled(StyledAccordionTrigger, {
+  '@hover': {
+    '&:hover': {
+      [`& ${StyledRadio}`]: {
+        boxShadow: 'inset 0 0 0 1px $colors$radioHoverBorder',
+        backgroundColor: '$radioHoverBg',
+      }
+    }
+  }
+})
+
 export const RadioAccordionTrigger = React.forwardRef<
-  React.ElementRef<typeof StyledAccordionTrigger>, AccordionTriggerProps>(({ children, ...props }, ref) => {
+  React.ElementRef<typeof StyledRadioAccordionTrigger>, AccordionTriggerProps>(({ children, ...props }, ref) => {
 
     return (
       <StyledAccordionHeader>
-        <StyledAccordionTrigger ref={ref} {...props}>
+        <StyledRadioAccordionTrigger ref={ref} {...props}>
           <StyledRadio >
             <StyledIndicator />
           </StyledRadio>
           {children}
-        </StyledAccordionTrigger>
+        </StyledRadioAccordionTrigger>
       </StyledAccordionHeader>
     )
   })

--- a/components/RadioAccordion/RadioAccordion.tsx
+++ b/components/RadioAccordion/RadioAccordion.tsx
@@ -5,7 +5,7 @@ import { INDICATOR_BASE_STYLES, RADIO_BASE_STYLES } from "../Radio";
 
 type RadioAccordionRootProps = Omit<VariantProps<typeof AccordionRoot>, 'type'>
 export const RadioAccordionRoot: (props: RadioAccordionRootProps) => JSX.Element = (props) => (
-  <AccordionRoot {...props} type='single' />
+  <AccordionRoot {...props} type='single' collapsible={false} />
 )
 export const RadioAccordionItem = React.forwardRef<React.ElementRef<typeof AccordionItem>, ComponentProps<typeof AccordionItem>>(({ value, children, ...props }, forwardedRef) => {
 

--- a/components/RadioAccordion/RadioAccordion.tsx
+++ b/components/RadioAccordion/RadioAccordion.tsx
@@ -1,0 +1,51 @@
+import React, { ComponentProps } from "react";
+import { styled, VariantProps } from "../../stitches.config";
+import { StyledAccordionTrigger, StyledAccordionHeader, AccordionRoot, AccordionContent, AccordionItem, AccordionTriggerProps } from "../Accordion";
+import { INDICATOR_BASE_STYLES, RADIO_BASE_STYLES } from "../Radio";
+
+type RadioAccordionRootProps = Omit<VariantProps<typeof AccordionRoot>, 'type'>
+export const RadioAccordionRoot: (props: RadioAccordionRootProps) => JSX.Element = (props) => (
+  <AccordionRoot {...props} type='single' />
+)
+export const RadioAccordionItem = React.forwardRef<React.ElementRef<typeof AccordionItem>, ComponentProps<typeof AccordionItem>>(({ value, children, ...props }, forwardedRef) => {
+
+  return (
+    <AccordionItem value={value} ref={forwardedRef} css={{ display: 'inherit', flexDirection: 'column' } as any} {...props}>
+      {children}
+    </AccordionItem>
+  );
+});
+
+const StyledRadio = styled('div', RADIO_BASE_STYLES, {
+  width: 18,
+  height: 18,
+  mr: '$2',
+})
+
+const StyledIndicator = styled('div', INDICATOR_BASE_STYLES, {
+  '&::after': {
+    '[data-state=open] &': {
+      backgroundColor: '$radioIndicator'
+    },
+    '[data-state=closed] &': {
+      backgroundColor: 'transparent',
+    }
+  },
+});
+
+export const RadioAccordionTrigger = React.forwardRef<
+  React.ElementRef<typeof StyledAccordionTrigger>, AccordionTriggerProps>(({ children, ...props }, ref) => {
+
+    return (
+      <StyledAccordionHeader>
+        <StyledAccordionTrigger ref={ref} {...props}>
+          <StyledRadio >
+            <StyledIndicator />
+          </StyledRadio>
+          {children}
+        </StyledAccordionTrigger>
+      </StyledAccordionHeader>
+    )
+  })
+
+export const RadioAccordionContent = AccordionContent

--- a/components/RadioAccordion/index.tsx
+++ b/components/RadioAccordion/index.tsx
@@ -1,0 +1,1 @@
+export * from './RadioAccordion';

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 export { AccordionRoot, AccordionItem, AccordionTrigger, AccordionContent } from './components/Accordion';
+export { RadioAccordionRoot, RadioAccordionItem, RadioAccordionTrigger, RadioAccordionContent } from './components/RadioAccordion';
 export { Alert } from './components/Alert';
 export { AspectRatio } from '@radix-ui/react-aspect-ratio';
 export { Badge } from './components/Badge';


### PR DESCRIPTION
# Description

Adds `RadioAccordion` component, following mockup

It depends on both `Accordion` and `Radio` styling.

It replaces the default `Chevron` inside `Accordion` with a decoration looking like a radiobutton: it's not an interactive input, it just reproduces the UI of `Radio`.

`RadioAccordion` enforces having a single panel open at a time, plus disables collapsing open panels.

See Radix primitive [Accordion](https://www.radix-ui.com/docs/primitives/components/accordion)

NB: currently `Accordion` exports `AccordionTrigger` as the default UI element, internally rendering an animated chevron. Customizations require exporting `StyledAccordionHeader` and `StyledAccordionTrigger`.

# Preview

https://user-images.githubusercontent.com/3367393/150810532-4ba13408-71c7-40f4-9d5c-372a70a882fd.mp4

# Before you ask

- Why not using a real radiobutton?

The radiobutton UI element would bring extra interactions for the user, but we want none of them.

We simply want an Accordion with more visual feedback than usual.