### PR TITLE
Feat!: improve field label behavior

### DIFF
--- a/components/Label/Label.stories.tsx
+++ b/components/Label/Label.stories.tsx
@@ -52,8 +52,6 @@ CapitalizedWords.args = {
 };
 ignoreArgType('id', CapitalizedWords);
 
-
-
 export const Uppercased = Template.bind({});
 Uppercased.args = {
   id: 'uppercase',
@@ -61,9 +59,47 @@ Uppercased.args = {
 };
 ignoreArgType('id', Uppercased);
 
-export const Error = Template.bind({});
-Error.args = {
-  id: 'err',
-  variant: 'red',
+export const Invalid = Template.bind({});
+Invalid.args = {
+  id: 'invalidvariant',
+  variant: 'invalid',
 };
-ignoreArgType('id', Error);
+ignoreArgType('id', Invalid);
+
+export const Disabled: ComponentStory<typeof LabelForStory> = ({ id, ...args }) => (
+  <Box>
+    <LabelForStory htmlFor={id} css={{ mr: '$2' }} variant="subtle" {...args}>
+      Email field
+    </LabelForStory>
+    <input id={id} name="email" type="email" disabled />
+  </Box>
+);
+Disabled.args = {
+  id: 'subtledisabled'
+}
+ignoreArgType('id', Disabled);
+
+export const FocusContrast: ComponentStory<typeof LabelForStory> = ({ id, ...args }) => {
+  const [hasFocus, setHasFocus] = React.useState(false);
+
+  const onFocus = React.useCallback(() => {
+    setHasFocus(true);
+  }, [setHasFocus])
+
+  const onBlur = React.useCallback(() => {
+    setHasFocus(false);
+  }, [setHasFocus])
+
+  return (
+    <Box>
+      <LabelForStory variant={hasFocus ? 'contrast' : 'default'} htmlFor={id} css={{ mr: '$2' }} {...args}>
+        Email field
+      </LabelForStory>
+      <input id={id} name="email" type="email" onFocus={onFocus} onBlur={onBlur} />
+    </Box>
+  );
+}
+FocusContrast.args = {
+  id: 'focuscontrastvariants'
+}
+ignoreArgType('id', FocusContrast)

--- a/components/Switch/Switch.stories.tsx
+++ b/components/Switch/Switch.stories.tsx
@@ -34,12 +34,10 @@ export const Disabled = Template.bind({});
 Disabled.args = { disabled: true };
 
 export const Labelled: ComponentStory<typeof SwitchForStory> = ({ id, ...args }) => (
-  <>
-    <Flex align="center">
-      <Label variant="contrast" htmlFor={id}>label</Label>
-      <SwitchForStory id={id} {...args} />
-    </Flex>
-  </>
+  <Flex align="center">
+    <Label variant="contrast" htmlFor={id}>label</Label>
+    <SwitchForStory id={id} {...args} />
+  </Flex>
 );
 Labelled.args = {
   id: 'labelled',

--- a/components/Switch/Switch.stories.tsx
+++ b/components/Switch/Switch.stories.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Switch, SwitchProps, SwitchVariants } from './Switch';
+import { Flex } from '../Flex';
+import { Label } from '../Label';
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
+import ignoreArgType from '../../utils/ignoreArgType';
 
 const BaseSwitch = (props: SwitchProps): JSX.Element => <Switch {...props} />;
 const SwitchForStory = modifyVariantsForStory<
@@ -29,3 +32,85 @@ Large.args = { size: '2' };
 export const Disabled = Template.bind({});
 
 Disabled.args = { disabled: true };
+
+export const Labelled: ComponentStory<typeof SwitchForStory> = ({ id, ...args }) => (
+  <>
+    <Flex align="center">
+      <Label variant="contrast" htmlFor={id}>label</Label>
+      <SwitchForStory id={id} {...args} />
+    </Flex>
+  </>
+);
+Labelled.args = {
+  id: 'labelled',
+};
+ignoreArgType('id', Labelled);
+
+interface ExtendedSwitchProps extends React.ComponentProps<typeof SwitchForStory> {
+  invalid?: boolean
+}
+
+export const LabelAndTitle: ComponentStory<(props: ExtendedSwitchProps) => JSX.Element> = ({ id, onFocus, onBlur, invalid, disabled, ...args }) => {
+  const [hasFocus, setHasFocus] = React.useState(false);
+
+  const titleVariant = React.useMemo(() => {
+    if (disabled) {
+      return 'subtle'
+    }
+    if (invalid) {
+      return 'invalid'
+    }
+    if (hasFocus) {
+      return 'contrast'
+    }
+    return 'default'
+  }, [invalid, disabled, hasFocus])
+
+  const labelVariant = React.useMemo(() => {
+    if (invalid) {
+      return 'invalid'
+    }
+    if (disabled) {
+      return 'subtle'
+    }
+    return 'contrast'
+  }, [invalid, disabled]
+  );
+
+
+  const handleFocus = React.useCallback(
+    (e) => {
+      if (onFocus) {
+        onFocus(e)
+      }
+      setHasFocus(true)
+    },
+    [onFocus, setHasFocus],
+  )
+
+  const handleBlur = React.useCallback(
+    (e) => {
+      if (onBlur) {
+        onBlur(e)
+      }
+      setHasFocus(false)
+    },
+    [onBlur, setHasFocus],
+  )
+
+  return (
+    <>
+      <Label htmlFor={id} variant={titleVariant}>title</Label>
+      <Flex align="center">
+        <Label variant={labelVariant} htmlFor={id}>label</Label>
+        <SwitchForStory id={id} disabled={disabled} onBlur={handleBlur} onFocus={handleFocus} {...args} />
+      </Flex>
+    </>
+  );
+}
+LabelAndTitle.args = {
+  id: 'label-title',
+  invalid: false,
+  disabled: false,
+}
+ignoreArgType('id', LabelAndTitle);

--- a/components/Text/Text.stories.tsx
+++ b/components/Text/Text.stories.tsx
@@ -24,7 +24,7 @@ export const Basic = Template.bind({});
 Basic.args = {};
 
 export const Variant: ComponentStory<typeof TextForStory> = ({ variant, ...args }) => (
-  <Flex gap={2}>
+  <Flex gap={2} direction="column">
     <TextForStory {...args} variant="default">
       Default
     </TextForStory>
@@ -35,7 +35,10 @@ export const Variant: ComponentStory<typeof TextForStory> = ({ variant, ...args 
       Contrast
     </TextForStory>
     <TextForStory {...args} variant="red">
-      Red
+      Red (error text)
+    </TextForStory>
+    <TextForStory {...args} variant="invalid">
+      Invalid (invalid field)
     </TextForStory>
   </Flex>
 );

--- a/components/Text/Text.themes.ts
+++ b/components/Text/Text.themes.ts
@@ -1,4 +1,5 @@
 import { Property } from '@stitches/react/types/css';
+import tinycolor from 'tinycolor2';
 import { ColorInfo } from '../../utils/getPrimaryColorInfo';
 
 export namespace Theme {
@@ -6,19 +7,25 @@ export namespace Theme {
     textSubtle: Property.Color;
     textDefault: Property.Color;
     textContrast: Property.Color;
+    textInvalid: Property.Color;
+    textRed: Property.Color;
   };
 
   type Factory = (primaryColor: ColorInfo) => Colors;
 
   export const getLight: Factory = (primaryColor) => ({
-    textSubtle: 'hsla(0, 0%, 0%, 0.51)',
-    textDefault: 'hsla(0, 0%, 0%, 0.74)',
-    textContrast: 'hsl(0, 0%, 0%)',
+    textSubtle: tinycolor('black').setAlpha(0.51).toHslString(),
+    textDefault: tinycolor('black').setAlpha(0.74).toHslString(),
+    textContrast: 'black',
+    textInvalid: '$red9',
+    textRed: '$red10',
   });
 
   export const getDark: Factory = (primaryColor) => ({
-    textSubtle: 'hsla(0, 0%, 100%, 0.51)',
-    textDefault: 'hsla(0, 0%, 100%, 0.74)',
-    textContrast: 'hsl(0, 0%, 100%)',
+    textSubtle: tinycolor('white').setAlpha(0.51).toHslString(),
+    textDefault: tinycolor('white').setAlpha(0.74).toHslString(),
+    textContrast: 'white',
+    textInvalid: '$red9',
+    textRed: '$red10',
   });
 }

--- a/components/Text/Text.tsx
+++ b/components/Text/Text.tsx
@@ -53,7 +53,7 @@ export const Text = styled('span', {
     },
     variant: {
       red: {
-        color: '$red10',
+        color: '$textRed',
       },
       subtle: {
         color: '$textSubtle',
@@ -64,6 +64,9 @@ export const Text = styled('span', {
       contrast: {
         color: '$textContrast',
       },
+      invalid: {
+        color: '$textInvalid'
+      }
     },
     gradient: {
       true: {
@@ -92,16 +95,6 @@ export const Text = styled('span', {
         overflow: 'hidden',
         textOverflow: 'ellipsis',
         whiteSpace: 'nowrap',
-      },
-    },
-    invalid: {
-      true: {
-        color: '$inputInvalidBorder',
-      },
-    },
-    disabled: {
-      true: {
-        color: '$inputDisabledText',
       },
     },
   },

--- a/components/TextField/TextField.tsx
+++ b/components/TextField/TextField.tsx
@@ -14,9 +14,7 @@ import {
 
 // TYPES
 export interface TextFieldLabelProps {
-  variant: 'red' | 'subtle' | 'contrast' | 'default'
-  disabled?: boolean
-  invalid?: boolean
+  variant: 'invalid' | 'subtle' | 'contrast' | 'default'
   htmlFor?: string
 }
 export type TextFieldProps = InputProps & {
@@ -79,11 +77,11 @@ export const TextField = React.forwardRef<React.ElementRef<typeof Input>, TextFi
     const invalid = React.useMemo(() => state === 'invalid', [state]);
 
     const labelVariant = React.useMemo(() => {
-      if (invalid) {
-        return 'red';
-      }
       if (disabled) {
         return 'subtle';
+      }
+      if (invalid) {
+        return 'invalid'
       }
       if (inputHasFocus) {
         return 'contrast';
@@ -98,16 +96,16 @@ export const TextField = React.forwardRef<React.ElementRef<typeof Input>, TextFi
         }
         if (typeof LabelOrComponent === 'string') {
           return (
-            <Label variant={labelVariant} disabled={disabled} invalid={invalid} htmlFor={id}>
+            <Label variant={labelVariant} htmlFor={id}>
               {LabelOrComponent}
             </Label>
           );
         }
         return (
-          <LabelOrComponent variant={labelVariant} disabled={disabled} invalid={invalid} htmlFor={id} />
+          <LabelOrComponent variant={labelVariant} htmlFor={id} />
         );
       },
-      [LabelOrComponent, labelVariant, disabled, invalid, id],
+      [LabelOrComponent, labelVariant, id],
     );
 
     const isPasswordType = React.useMemo(() => type === 'password', [type]);

--- a/components/Textarea/Textarea.tsx
+++ b/components/Textarea/Textarea.tsx
@@ -230,11 +230,11 @@ export const Textarea = React.forwardRef<React.ElementRef<typeof StyledTextarea>
     const invalid = React.useMemo(() => state === 'invalid', [state]);
 
     const labelVariant = React.useMemo(() => {
-      if (invalid) {
-        return 'red';
-      }
       if (disabled) {
         return 'subtle';
+      }
+      if (invalid) {
+        return 'invalid';
       }
       if (hasFocus) {
         return 'contrast';
@@ -265,7 +265,7 @@ export const Textarea = React.forwardRef<React.ElementRef<typeof StyledTextarea>
     return (
       <Box css={rootCss as any}>
         {label && (
-          <Label variant={labelVariant} disabled={disabled} invalid={invalid} htmlFor={id} css={{ display: 'block' }}>
+          <Label variant={labelVariant} htmlFor={id} css={{ display: 'block' }}>
             {label}
           </Label>
         )}


### PR DESCRIPTION
# Description

Improve field label behaviour and simplify label color computation.

Until now, `TextField` was applying conflicting rules to its `Label`, for instance:
- `variant: 'red'` + `invalid` when it was invalid
- `variant: 'subtle'` + `disabled` when it was disabled

Expectations where mislead by this and the result did not match them.

# How to test

Check `Label`, `Text`, `TextField`, `Textarea` and `Switch` stories 

# :warning:  Breaking changes

## Text

Reworked text variants related to label behavior inside forms:
- disabled label
- invalid label

Instead of having separate variants, I merged them together inside `variant`

![image](https://user-images.githubusercontent.com/3367393/151537989-ac0febae-c004-4e36-ae55-c6ca2482550b.png)

Added stories.

## Label

Added stories to follow `Text` changes and display some implementations we made in other places.


# Changes

## TextField

Updated `TextField` label props accordingly

## Textarea

Update `Textarea` label props accordingly

## Switch

I noticed I didn't write stories to show examples of having a Switch with a label.

I wrote 2 stories to follow our mockups: 
![image](https://user-images.githubusercontent.com/3367393/151537412-c2497483-0951-477a-bc58-74bf040aefe2.png)

For example with 2 labels, the behaviour for invalid and disabled states and their compound is a design proposal I made, to try following a similar behaviour to that of `TextField`. I hope we'll have this validated or changed by a mockup one day :pray: 
If you have opinions, I'm up to applying them.

I suppose I could move this part to a separate PR if you prefer. I kept it here simply because I don't add features to the component, but related documentation.