### PR TITLE
fix: radio accordion root, props should not include collapsible

### DIFF
--- a/components/RadioAccordion/RadioAccordion.tsx
+++ b/components/RadioAccordion/RadioAccordion.tsx
@@ -2,10 +2,12 @@ import React, { ComponentProps } from "react";
 import { styled, VariantProps } from "../../stitches.config";
 import { StyledAccordionTrigger, StyledAccordionHeader, AccordionRoot, AccordionContent, AccordionItem, AccordionTriggerProps } from "../Accordion";
 import { INDICATOR_BASE_STYLES, RADIO_BASE_STYLES } from "../Radio";
+import type { AccordionSingleProps } from '@radix-ui/react-accordion'
 
-type RadioAccordionRootProps = Omit<VariantProps<typeof AccordionRoot>, 'type' | 'collapsible'>
+export interface RadioAccordionRootProps extends Omit<AccordionSingleProps, 'type' | 'collapsible' | 'css'>, Omit<VariantProps<typeof AccordionRoot>, 'type' | 'collapsible'> { }
+
 export const RadioAccordionRoot: (props: RadioAccordionRootProps) => JSX.Element = (props) => (
-  <AccordionRoot {...props} type='single' collapsible={false} />
+  <AccordionRoot {...props} type="single" collapsible={false} />
 )
 export const RadioAccordionItem = React.forwardRef<React.ElementRef<typeof AccordionItem>, ComponentProps<typeof AccordionItem>>(({ value, children, ...props }, forwardedRef) => {
 

--- a/components/RadioAccordion/RadioAccordion.tsx
+++ b/components/RadioAccordion/RadioAccordion.tsx
@@ -3,7 +3,7 @@ import { styled, VariantProps } from "../../stitches.config";
 import { StyledAccordionTrigger, StyledAccordionHeader, AccordionRoot, AccordionContent, AccordionItem, AccordionTriggerProps } from "../Accordion";
 import { INDICATOR_BASE_STYLES, RADIO_BASE_STYLES } from "../Radio";
 
-type RadioAccordionRootProps = Omit<VariantProps<typeof AccordionRoot>, 'type'>
+type RadioAccordionRootProps = Omit<VariantProps<typeof AccordionRoot>, 'type' | 'collapsible'>
 export const RadioAccordionRoot: (props: RadioAccordionRootProps) => JSX.Element = (props) => (
   <AccordionRoot {...props} type='single' collapsible={false} />
 )


### PR DESCRIPTION
# Description

`collapsible` and `type` props should not be allowed, nor required for `AccordionRoot`