### PR TITLE
Feat: aria table

### DIFF
--- a/components/AriaTable/AriaTable.stories.tsx
+++ b/components/AriaTable/AriaTable.stories.tsx
@@ -20,10 +20,12 @@ export const Basic: ComponentStory<any> = ({ transform, ...args }) => (
     <TableForStory aria-label="People" aria-describedby="basic-table-caption" {...args}>
       <Caption id="basic-table-caption">People with some information</Caption>
       <Thead>
-        <Th transform={transform}>first name</Th>
-        <Th transform={transform}>last name</Th>
-        <Th transform={transform}>Status</Th>
-        <Th transform={transform}>Role</Th>
+        <Tr>
+          <Th transform={transform}>first name</Th>
+          <Th transform={transform}>last name</Th>
+          <Th transform={transform}>Status</Th>
+          <Th transform={transform}>Role</Th>
+        </Tr>
       </Thead>
       <Tbody>
         <Tr>
@@ -83,10 +85,12 @@ export const Alignment: ComponentStory<any> = (args) => (
   <Card>
     <TableForStory>
       <Thead>
-        <Th {...args}>Firstname</Th>
-        <Th {...args}>Lastname</Th>
-        <Th {...args}>Status</Th>
-        <Th {...args}>Role</Th>
+        <Tr>
+          <Th {...args}>Firstname</Th>
+          <Th {...args}>Lastname</Th>
+          <Th {...args}>Status</Th>
+          <Th {...args}>Role</Th>
+        </Tr>
       </Thead>
       <Tbody>
         <Tr>
@@ -141,10 +145,12 @@ export const Interactive: ComponentStory<any> = (args) => (
   <Card>
     <TableForStory>
       <Thead>
-        <Th>Firstname</Th>
-        <Th>Lastname</Th>
-        <Th>Status</Th>
-        <Th>Role</Th>
+        <Tr>
+          <Th>Firstname</Th>
+          <Th>Lastname</Th>
+          <Th>Status</Th>
+          <Th>Role</Th>
+        </Tr>
       </Thead>
       <Tbody>
         <Tr {...args}>

--- a/components/AriaTable/AriaTable.stories.tsx
+++ b/components/AriaTable/AriaTable.stories.tsx
@@ -106,7 +106,7 @@ export const Alignment: ComponentStory<any> = (args) => (
           <Td {...args}>
             <Badge variant="orange">AFK</Badge>
           </Td>
-          <Td>Actor</Td>
+          <Td {...args}>Actor</Td>
         </Tr>
         <Tr>
           <Td {...args}>Natalie</Td>

--- a/components/AriaTable/AriaTable.stories.tsx
+++ b/components/AriaTable/AriaTable.stories.tsx
@@ -3,8 +3,7 @@ import React from 'react';
 import { Table, TableProps, TableVariants, Tbody, Td, Th, Thead, Tr, Caption } from './AriaTable';
 import { Badge } from '../Badge';
 import { Card } from '../Card';
-import { Flex } from '../Flex';
-import { Text } from '../Text';
+import { UnstyledLink } from '../Link';
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
 
 const BaseTable = (props: TableProps): JSX.Element => <Table {...props} />;
@@ -193,3 +192,31 @@ export const Interactive: ComponentStory<any> = (args) => (
 Interactive.args = {
   interactive: true,
 };
+
+export const Links: ComponentStory<any> = (args) => (
+  <Card>
+    <TableForStory aria-label="Empty" aria-describedby="empty-table-caption" {...args}>
+      <Caption id="empty-table-caption">Table with empty data</Caption>
+      <Thead>
+        <Tr>
+          <Th>first name</Th>
+          <Th>last name</Th>
+          <Th>Status</Th>
+          <Th>Role</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        <Tr interactive asChild>
+          <UnstyledLink href="https://traefik.io">
+            <Td>John</Td>
+            <Td>Doe</Td>
+            <Td>
+              <Badge variant="green">Connected</Badge>
+            </Td>
+            <Td>Developer</Td>
+          </UnstyledLink>
+        </Tr>
+      </Tbody>
+    </TableForStory>
+  </Card>
+)

--- a/components/AriaTable/AriaTable.stories.tsx
+++ b/components/AriaTable/AriaTable.stories.tsx
@@ -1,0 +1,189 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import React from 'react';
+import { Table, TableProps, TableVariants, Tbody, Td, Th, Thead, Tr, Caption } from './AriaTable';
+import { Badge } from '../Badge';
+import { Card } from '../Card';
+import { Flex } from '../Flex';
+import { Text } from '../Text';
+import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
+
+const BaseTable = (props: TableProps): JSX.Element => <Table {...props} />;
+const TableForStory = modifyVariantsForStory<TableVariants, TableProps>(BaseTable);
+
+export default {
+  title: 'Components/AriaTable',
+  component: TableForStory,
+} as ComponentMeta<typeof TableForStory>;
+
+export const Basic: ComponentStory<any> = ({ transform, ...args }) => (
+  <Card>
+    <TableForStory aria-label="People" aria-describedby="basic-table-caption" {...args}>
+      <Caption id="basic-table-caption">People with some information</Caption>
+      <Thead>
+        <Th transform={transform}>first name</Th>
+        <Th transform={transform}>last name</Th>
+        <Th transform={transform}>Status</Th>
+        <Th transform={transform}>Role</Th>
+      </Thead>
+      <Tbody>
+        <Tr>
+          <Td>John</Td>
+          <Td>Doe</Td>
+          <Td>
+            <Badge variant="green">Connected</Badge>
+          </Td>
+          <Td>Developer</Td>
+        </Tr>
+        <Tr>
+          <Td>Johny</Td>
+          <Td>Depp</Td>
+          <Td>
+            <Badge variant="orange">AFK</Badge>
+          </Td>
+          <Td>Actor</Td>
+        </Tr>
+        <Tr>
+          <Td>Natalie</Td>
+          <Td>Portman</Td>
+          <Td>
+            <Badge variant="green">Connected</Badge>
+          </Td>
+          <Td>Actor</Td>
+        </Tr>
+        <Tr>
+          <Td>Luke</Td>
+          <Td>Skywalker</Td>
+          <Td>
+            <Badge variant="red">Disconnected</Badge>
+          </Td>
+          <Td>Star wars</Td>
+        </Tr>
+      </Tbody>
+    </TableForStory>
+  </Card>
+);
+
+Basic.args = {
+  transform: 'capitalize',
+};
+Basic.argTypes = {
+  transform: {
+    control: 'inline-radio',
+    options: ['capitalize', 'capitalizeWords', 'uppercase', 'none'],
+    mapping: {
+      capitalize: 'capitalize',
+      capitalizeWords: 'capitalizeWords',
+      uppercase: 'uppercase',
+      none: '',
+    }
+  },
+};
+
+export const Alignment: ComponentStory<any> = (args) => (
+  <Card>
+    <TableForStory>
+      <Thead>
+        <Th {...args}>Firstname</Th>
+        <Th {...args}>Lastname</Th>
+        <Th {...args}>Status</Th>
+        <Th {...args}>Role</Th>
+      </Thead>
+      <Tbody>
+        <Tr>
+          <Td {...args}>John</Td>
+          <Td {...args}>Doe</Td>
+          <Td {...args}>
+            <Badge variant="green">Connected</Badge>
+          </Td>
+          <Td {...args}>Developer</Td>
+        </Tr>
+        <Tr>
+          <Td {...args}>Johny</Td>
+          <Td {...args}>Depp</Td>
+          <Td {...args}>
+            <Badge variant="orange">AFK</Badge>
+          </Td>
+          <Td>Actor</Td>
+        </Tr>
+        <Tr>
+          <Td {...args}>Natalie</Td>
+          <Td {...args}>Portman</Td>
+          <Td {...args}>
+            <Badge variant="green">Connected</Badge>
+          </Td>
+          <Td {...args}>Actor</Td>
+        </Tr>
+        <Tr>
+          <Td {...args}>Luke</Td>
+          <Td {...args}>Skywalker</Td>
+          <Td {...args}>
+            <Badge variant="red">Disconnected</Badge>
+          </Td>
+          <Td {...args}>Star wars</Td>
+        </Tr>
+      </Tbody>
+    </TableForStory>
+  </Card>
+);
+
+Alignment.argTypes = {
+  align: {
+    control: 'inline-radio',
+    options: ['start', 'center', 'end'],
+  },
+};
+
+Alignment.args = {
+  align: 'start',
+};
+
+export const Interactive: ComponentStory<any> = (args) => (
+  <Card>
+    <TableForStory>
+      <Thead>
+        <Th>Firstname</Th>
+        <Th>Lastname</Th>
+        <Th>Status</Th>
+        <Th>Role</Th>
+      </Thead>
+      <Tbody>
+        <Tr {...args}>
+          <Td>John</Td>
+          <Td>Doe</Td>
+          <Td>
+            <Badge variant="green">Connected</Badge>
+          </Td>
+          <Td>Developer</Td>
+        </Tr>
+        <Tr {...args}>
+          <Td>Johny</Td>
+          <Td>Depp</Td>
+          <Td>
+            <Badge variant="orange">AFK</Badge>
+          </Td>
+          <Td>Actor</Td>
+        </Tr>
+        <Tr {...args} active>
+          <Td>Natalie</Td>
+          <Td>Portman</Td>
+          <Td>
+            <Badge variant="green">Connected</Badge>
+          </Td>
+          <Td>Actor</Td>
+        </Tr>
+        <Tr {...args}>
+          <Td>Luke</Td>
+          <Td>Skywalker</Td>
+          <Td>
+            <Badge variant="red">Disconnected</Badge>
+          </Td>
+          <Td>Star Wars</Td>
+        </Tr>
+      </Tbody>
+    </TableForStory>
+  </Card>
+);
+
+Interactive.args = {
+  interactive: true,
+};

--- a/components/AriaTable/AriaTable.tsx
+++ b/components/AriaTable/AriaTable.tsx
@@ -1,0 +1,63 @@
+import { ComponentProps, ElementRef, forwardRef } from 'react';
+import { styled, VariantProps } from '../../stitches.config';
+import { Caption as TableCaption, Tbody as TableTbody, Tfoot as TableTfoot, Tr as TableTr, Th as TableTh, Td as TableTd, Thead as TableThead, Table as TableTable } from '../Table';
+
+export const Caption = styled('div', TableCaption, {
+  display: 'table-caption',
+});
+
+const StyledTbody = styled('div', TableTbody, {
+  display: 'table-row-group',
+});
+export const Tbody = forwardRef<ElementRef<typeof StyledTbody>, Omit<ComponentProps<typeof StyledTbody>, 'css'> & VariantProps<typeof StyledTbody>>((props, ref) => (
+  <StyledTbody ref={ref} role="rowgroup" {...props} />
+))
+
+const StyledTfoot = styled('div', TableTfoot, {
+  display: 'table-footer-group',
+});
+export const Tfoot = forwardRef<ElementRef<typeof StyledTfoot>, Omit<ComponentProps<typeof StyledTfoot>, 'css'> & VariantProps<typeof StyledTfoot>>((props, ref) => (
+  <StyledTfoot ref={ref} role="rowgroup" {...props} />
+))
+
+const StyledTr = styled('div', TableTr, {
+  display: 'table-row',
+});
+export const Tr = forwardRef<ElementRef<typeof StyledTr>, Omit<ComponentProps<typeof StyledTr>, 'css'> & VariantProps<typeof StyledTr>>((props, ref) => (
+  <StyledTr ref={ref} role="row" {...props} />
+))
+
+const StyledTh = styled('span', TableTh, {
+  display: 'table-cell'
+});
+export interface ThProps extends Omit<ComponentProps<typeof StyledTh>, 'css'>, VariantProps<typeof StyledTh> { }
+export const Th = forwardRef<
+  ElementRef<typeof StyledTh>,
+  ThProps>((props, ref) => (
+    <StyledTh ref={ref} role="columnheader" {...props} />
+  ))
+
+
+const StyledTd = styled('span', TableTd, {
+  display: 'table-cell',
+});
+export const Td = forwardRef<ElementRef<typeof StyledTd>, Omit<ComponentProps<typeof StyledTd>, 'css'> & VariantProps<typeof StyledTd>>((props, ref) => (
+  <StyledTd ref={ref} role="cell" {...props} />
+))
+
+const StyledThead = styled('div', {
+  display: 'table-header-group',
+});
+export const Thead = forwardRef<ElementRef<typeof StyledThead>, Omit<ComponentProps<typeof StyledThead>, 'css'> & VariantProps<typeof StyledThead>>((props, ref) => (
+  <StyledThead ref={ref} role="rowgroup" {...props} />
+))
+
+const StyledTable = styled('div', TableTable, {
+  display: 'table',
+});
+export const Table = forwardRef<ElementRef<typeof StyledTable>, Omit<ComponentProps<typeof StyledTable>, 'css'> & VariantProps<typeof StyledTable>>((props, ref) => (
+  <StyledTable ref={ref} role="table" {...props} />
+))
+
+export type TableVariants = VariantProps<typeof Table>;
+export type TableProps = TableVariants & {};

--- a/components/AriaTable/AriaTable.tsx
+++ b/components/AriaTable/AriaTable.tsx
@@ -1,5 +1,5 @@
+import React, { ComponentProps, ElementRef, forwardRef } from 'react';
 import { Slot } from '@radix-ui/react-slot';
-import { ComponentProps, ElementRef, forwardRef } from 'react';
 import { styled, VariantProps } from '../../stitches.config';
 import { Caption as TableCaption, Tbody as TableTbody, Tfoot as TableTfoot, Tr as TableTr, Th as TableTh, Td as TableTd, Thead as TableThead, Table as TableTable } from '../Table';
 

--- a/components/AriaTable/AriaTable.tsx
+++ b/components/AriaTable/AriaTable.tsx
@@ -1,3 +1,4 @@
+import { Slot } from '@radix-ui/react-slot';
 import { ComponentProps, ElementRef, forwardRef } from 'react';
 import { styled, VariantProps } from '../../stitches.config';
 import { Caption as TableCaption, Tbody as TableTbody, Tfoot as TableTfoot, Tr as TableTr, Th as TableTh, Td as TableTd, Thead as TableThead, Table as TableTable } from '../Table';
@@ -23,9 +24,17 @@ export const Tfoot = forwardRef<ElementRef<typeof StyledTfoot>, Omit<ComponentPr
 const StyledTr = styled('div', TableTr, {
   display: 'table-row',
 });
-export const Tr = forwardRef<ElementRef<typeof StyledTr>, Omit<ComponentProps<typeof StyledTr>, 'css'> & VariantProps<typeof StyledTr>>((props, ref) => (
-  <StyledTr ref={ref} role="row" {...props} />
-))
+const StyledTrSlot = styled(Slot, StyledTr);
+export interface TrProps extends Omit<ComponentProps<typeof StyledTr>, 'css'>, VariantProps<typeof StyledTr> {
+  asChild?: boolean
+}
+export const Tr = forwardRef<ElementRef<typeof StyledTr>, TrProps>(({ asChild, ...props }, ref) => {
+  const Component = asChild ? StyledTrSlot : StyledTr;
+
+  return (
+    <Component ref={ref} role="row" {...props} />
+  )
+})
 
 const StyledTh = styled('span', TableTh, {
   display: 'table-cell'
@@ -45,7 +54,7 @@ export const Td = forwardRef<ElementRef<typeof StyledTd>, Omit<ComponentProps<ty
   <StyledTd ref={ref} role="cell" {...props} />
 ))
 
-const StyledThead = styled('div', {
+const StyledThead = styled('div', TableThead, {
   display: 'table-header-group',
 });
 export const Thead = forwardRef<ElementRef<typeof StyledThead>, Omit<ComponentProps<typeof StyledThead>, 'css'> & VariantProps<typeof StyledThead>>((props, ref) => (

--- a/components/AriaTable/index.ts
+++ b/components/AriaTable/index.ts
@@ -1,0 +1,1 @@
+export * from './AriaTable';

--- a/components/Link/Link.tsx
+++ b/components/Link/Link.tsx
@@ -1,6 +1,12 @@
 import { styled } from '../../stitches.config';
 import { Text } from '../Text';
 
+export const UnstyledLink = styled('a', {
+  color: 'inherit',
+  textDecoration: 'inherit',
+  fontWeight: 'inherit',
+});
+
 export const Link = styled('a', {
   alignItems: 'center',
   gap: '$1',

--- a/components/Table/Table.stories.tsx
+++ b/components/Table/Table.stories.tsx
@@ -17,10 +17,12 @@ export const Basic: ComponentStory<any> = ({ transform, ...args }) => (
   <Card>
     <TableForStory {...args}>
       <Thead>
-        <Th transform={transform}>first name</Th>
-        <Th transform={transform}>last name</Th>
-        <Th transform={transform}>Status</Th>
-        <Th transform={transform}>Role</Th>
+        <Tr>
+          <Th transform={transform}>first name</Th>
+          <Th transform={transform}>last name</Th>
+          <Th transform={transform}>Status</Th>
+          <Th transform={transform}>Role</Th>
+        </Tr>
       </Thead>
       <Tbody>
         <Tr>
@@ -80,10 +82,12 @@ export const Alignment: ComponentStory<any> = (args) => (
   <Card>
     <TableForStory>
       <Thead>
-        <Th {...args}>Firstname</Th>
-        <Th {...args}>Lastname</Th>
-        <Th {...args}>Status</Th>
-        <Th {...args}>Role</Th>
+        <Tr>
+          <Th {...args}>Firstname</Th>
+          <Th {...args}>Lastname</Th>
+          <Th {...args}>Status</Th>
+          <Th {...args}>Role</Th>
+        </Tr>
       </Thead>
       <Tbody>
         <Tr>
@@ -138,10 +142,12 @@ export const Interactive: ComponentStory<any> = (args) => (
   <Card>
     <TableForStory>
       <Thead>
-        <Th>Firstname</Th>
-        <Th>Lastname</Th>
-        <Th>Status</Th>
-        <Th>Role</Th>
+        <Tr>
+          <Th>Firstname</Th>
+          <Th>Lastname</Th>
+          <Th>Status</Th>
+          <Th>Role</Th>
+        </Tr>
       </Thead>
       <Tbody>
         <Tr {...args}>

--- a/index.ts
+++ b/index.ts
@@ -45,6 +45,7 @@ export { Radio, RadioGroup } from './components/Radio';
 export { Select } from './components/Select';
 export { Skeleton } from './components/Skeleton';
 export { Switch } from './components/Switch';
+export { Caption as AriaCaption, Tbody as AriaTbody, Tfoot as AriaTfoot, Tr as AriaTr, Th as AriaTh, Td as AriaTd, Thead as AriaThead, Table as AriaTable } from './components/AriaTable'
 export { Caption, Tbody, Tfoot, Tr, Th, Td, Thead, Table } from './components/Table';
 export { Text } from './components/Text';
 export { Tooltip } from './components/Tooltip';

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@traefiklabs/faency",
-      "version": "1.0.0-8",
+      "version": "1.0.0-9",
       "dependencies": {
         "@radix-ui/colors": "0.1.7",
         "@radix-ui/react-accordion": "0.1.5",
@@ -27,6 +27,7 @@
         "@radix-ui/react-radio-group": "0.1.1",
         "@radix-ui/react-separator": "0.1.1",
         "@radix-ui/react-slider": "0.1.1",
+        "@radix-ui/react-slot": "0.1.2",
         "@radix-ui/react-switch": "0.1.1",
         "@radix-ui/react-tabs": "0.1.1",
         "@radix-ui/react-toggle": "0.1.1",
@@ -2997,18 +2998,6 @@
         "react": "^16.8 || ^17.0"
       }
     },
-    "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.2.tgz",
-      "integrity": "sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "0.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
     "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-id": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-0.1.4.tgz",
@@ -3033,18 +3022,6 @@
         "react": "^16.8 || ^17.0"
       }
     },
-    "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.2.tgz",
-      "integrity": "sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "0.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
     "node_modules/@radix-ui/react-alert-dialog": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-0.1.1.tgz",
@@ -3060,6 +3037,18 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.1.tgz",
+      "integrity": "sha512-deq3K7cCXQ+tWMZF2GKl3zGMcwVbyQDiMY/UcPI0Q1DDudRG2dWrEwcYbYajEelc07oOxzNyKpaXZLOpNxquuA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
       }
     },
     "node_modules/@radix-ui/react-arrow": {
@@ -3131,6 +3120,18 @@
         "@radix-ui/react-context": "0.1.1",
         "@radix-ui/react-primitive": "0.1.1",
         "@radix-ui/react-slot": "0.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.1.tgz",
+      "integrity": "sha512-deq3K7cCXQ+tWMZF2GKl3zGMcwVbyQDiMY/UcPI0Q1DDudRG2dWrEwcYbYajEelc07oOxzNyKpaXZLOpNxquuA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "0.1.0"
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0"
@@ -3409,6 +3410,18 @@
         "react": "^16.8 || ^17.0"
       }
     },
+    "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.1.tgz",
+      "integrity": "sha512-deq3K7cCXQ+tWMZF2GKl3zGMcwVbyQDiMY/UcPI0Q1DDudRG2dWrEwcYbYajEelc07oOxzNyKpaXZLOpNxquuA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
     "node_modules/@radix-ui/react-progress": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-0.1.1.tgz",
@@ -3497,9 +3510,9 @@
       }
     },
     "node_modules/@radix-ui/react-slot": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.1.tgz",
-      "integrity": "sha512-deq3K7cCXQ+tWMZF2GKl3zGMcwVbyQDiMY/UcPI0Q1DDudRG2dWrEwcYbYajEelc07oOxzNyKpaXZLOpNxquuA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.2.tgz",
+      "integrity": "sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-compose-refs": "0.1.0"
@@ -3584,6 +3597,18 @@
       "peerDependencies": {
         "react": "^16.8 || ^17.0",
         "react-dom": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.1.tgz",
+      "integrity": "sha512-deq3K7cCXQ+tWMZF2GKl3zGMcwVbyQDiMY/UcPI0Q1DDudRG2dWrEwcYbYajEelc07oOxzNyKpaXZLOpNxquuA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
       }
     },
     "node_modules/@radix-ui/react-use-body-pointer-events": {
@@ -25410,17 +25435,6 @@
             "@radix-ui/react-context": "0.1.1",
             "@radix-ui/react-primitive": "0.1.3",
             "@radix-ui/react-slot": "0.1.2"
-          },
-          "dependencies": {
-            "@radix-ui/react-slot": {
-              "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.2.tgz",
-              "integrity": "sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==",
-              "requires": {
-                "@babel/runtime": "^7.13.10",
-                "@radix-ui/react-compose-refs": "0.1.0"
-              }
-            }
           }
         },
         "@radix-ui/react-id": {
@@ -25439,17 +25453,6 @@
           "requires": {
             "@babel/runtime": "^7.13.10",
             "@radix-ui/react-slot": "0.1.2"
-          },
-          "dependencies": {
-            "@radix-ui/react-slot": {
-              "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.2.tgz",
-              "integrity": "sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==",
-              "requires": {
-                "@babel/runtime": "^7.13.10",
-                "@radix-ui/react-compose-refs": "0.1.0"
-              }
-            }
           }
         }
       }
@@ -25465,6 +25468,17 @@
         "@radix-ui/react-context": "0.1.1",
         "@radix-ui/react-dialog": "0.1.1",
         "@radix-ui/react-slot": "0.1.1"
+      },
+      "dependencies": {
+        "@radix-ui/react-slot": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.1.tgz",
+          "integrity": "sha512-deq3K7cCXQ+tWMZF2GKl3zGMcwVbyQDiMY/UcPI0Q1DDudRG2dWrEwcYbYajEelc07oOxzNyKpaXZLOpNxquuA==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/react-compose-refs": "0.1.0"
+          }
+        }
       }
     },
     "@radix-ui/react-arrow": {
@@ -25524,6 +25538,17 @@
         "@radix-ui/react-context": "0.1.1",
         "@radix-ui/react-primitive": "0.1.1",
         "@radix-ui/react-slot": "0.1.1"
+      },
+      "dependencies": {
+        "@radix-ui/react-slot": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.1.tgz",
+          "integrity": "sha512-deq3K7cCXQ+tWMZF2GKl3zGMcwVbyQDiMY/UcPI0Q1DDudRG2dWrEwcYbYajEelc07oOxzNyKpaXZLOpNxquuA==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/react-compose-refs": "0.1.0"
+          }
+        }
       }
     },
     "@radix-ui/react-compose-refs": {
@@ -25741,6 +25766,17 @@
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-slot": "0.1.1"
+      },
+      "dependencies": {
+        "@radix-ui/react-slot": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.1.tgz",
+          "integrity": "sha512-deq3K7cCXQ+tWMZF2GKl3zGMcwVbyQDiMY/UcPI0Q1DDudRG2dWrEwcYbYajEelc07oOxzNyKpaXZLOpNxquuA==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/react-compose-refs": "0.1.0"
+          }
+        }
       }
     },
     "@radix-ui/react-progress": {
@@ -25816,9 +25852,9 @@
       }
     },
     "@radix-ui/react-slot": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.1.tgz",
-      "integrity": "sha512-deq3K7cCXQ+tWMZF2GKl3zGMcwVbyQDiMY/UcPI0Q1DDudRG2dWrEwcYbYajEelc07oOxzNyKpaXZLOpNxquuA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.2.tgz",
+      "integrity": "sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-compose-refs": "0.1.0"
@@ -25887,6 +25923,17 @@
         "@radix-ui/react-use-previous": "0.1.0",
         "@radix-ui/react-use-rect": "0.1.1",
         "@radix-ui/react-visually-hidden": "0.1.1"
+      },
+      "dependencies": {
+        "@radix-ui/react-slot": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.1.tgz",
+          "integrity": "sha512-deq3K7cCXQ+tWMZF2GKl3zGMcwVbyQDiMY/UcPI0Q1DDudRG2dWrEwcYbYajEelc07oOxzNyKpaXZLOpNxquuA==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/react-compose-refs": "0.1.0"
+          }
+        }
       }
     },
     "@radix-ui/react-use-body-pointer-events": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@radix-ui/react-radio-group": "0.1.1",
     "@radix-ui/react-separator": "0.1.1",
     "@radix-ui/react-slider": "0.1.1",
+    "@radix-ui/react-slot": "0.1.2",
     "@radix-ui/react-switch": "0.1.1",
     "@radix-ui/react-tabs": "0.1.1",
     "@radix-ui/react-toggle": "0.1.1",


### PR DESCRIPTION
# Description

- Adds an ARIA-role based table
  - all its structure is made of `div`s and `span`s with proper roles and `display` 
- Adds an unstyled link component
- Adds similar stories as `Table`
- Adds a story showing how to build links as table rows

All recommendations and best practices I read where explicitly telling to avoid using an Aria Table unless other layouts are impossible.

## Use case: each row is an anchor tag

My use case justifying this component over the basic `Table` is to allow having links as table rows.

There are some workarounds as described [here](https://robertcooper.me/post/table-row-links), but in the end, this implementation seems the most accessible outcome for my specific use case.

# Sources

WAI-ARIA
- [wai-aria practices](https://www.w3.org/TR/wai-aria-practices/#table)
- [table example](https://www.w3.org/TR/wai-aria-practices/examples/table/table.html)

MDN
- [table role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/table_role)
- [css display](https://developer.mozilla.org/en-US/docs/Web/CSS/display)

# Preview

https://user-images.githubusercontent.com/3367393/152006653-89221641-6068-4563-b3e4-89371db1a1b4.mp4


# Dependency changes

<!--
If there were changes in the dependencies, please mention them here. Added/Updated/Removed dependencies.
For added dependencies, it's nice to have a description of why it was needed.
-->

| Dependency | Version        | State   |
| ---------- | -------------- | ------- |
| [`@radix-ui/react-slot`](https://www.radix-ui.com/docs/primitives/utilities/slot)       | 0.1.2          | Added   |

- [slot](https://www.radix-ui.com/docs/primitives/utilities/slot) allows building components with `asChild` pattern exactly like Radix team does :tada: 
