### PR TITLE
fix: inherit `border-radius` on table children elements

### DIFF
--- a/components/Table/Table.stories.tsx
+++ b/components/Table/Table.stories.tsx
@@ -1,6 +1,17 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import React, { useCallback, useState } from 'react';
-import { Table, TableProps, TableVariants, Tbody, Td, Th, Thead, Tr, Tfoot, Caption } from './Table';
+import {
+  Table,
+  TableProps,
+  TableVariants,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  Tfoot,
+  Caption,
+} from './Table';
 import { Badge } from '../Badge';
 import { Flex } from '../Flex';
 import { Heading } from '../Heading';
@@ -217,15 +228,17 @@ Interactive.argTypes = {
   elevation: {
     control: 'inline-radio',
     options: ['1', '2', '3', '4', '5'],
-  }
-}
+  },
+};
 export const WithFooter: ComponentStory<any> = (args) => (
   <TableForStory {...args}>
     <Thead>
-      <Th>Firstname</Th>
-      <Th>Lastname</Th>
-      <Th>Status</Th>
-      <Th>Role</Th>
+      <Tr>
+        <Th>Firstname</Th>
+        <Th>Lastname</Th>
+        <Th>Status</Th>
+        <Th>Role</Th>
+      </Tr>
     </Thead>
     <Tbody>
       <Tr>
@@ -263,27 +276,27 @@ export const WithFooter: ComponentStory<any> = (args) => (
     </Tbody>
     <Tfoot>
       <Tr>
-        <Td colSpan={4}>
-          Footer information
-        </Td>
+        <Td colSpan={4}>Footer information</Td>
       </Tr>
     </Tfoot>
   </TableForStory>
-)
+);
 
 export const WithCaption: ComponentStory<any> = (args) => {
-  const id = "described-heading"
-  const title = 'Title not child of table'
+  const id = 'described-heading';
+  const title = 'Title not child of table';
   return (
     <>
       <Flex direction="column" gap="4">
         <TableForStory {...args}>
           <Caption size="10">Caption child of table</Caption>
           <Thead>
-            <Th>Firstname</Th>
-            <Th>Lastname</Th>
-            <Th>Status</Th>
-            <Th>Role</Th>
+            <Tr>
+              <Th>Firstname</Th>
+              <Th>Lastname</Th>
+              <Th>Status</Th>
+              <Th>Role</Th>
+            </Tr>
           </Thead>
           <Tbody>
             <Tr>
@@ -329,10 +342,12 @@ export const WithCaption: ComponentStory<any> = (args) => {
               <Caption>{title}</Caption>
             </VisuallyHidden>
             <Thead>
-              <Th>Firstname</Th>
-              <Th>Lastname</Th>
-              <Th>Status</Th>
-              <Th>Role</Th>
+              <Tr>
+                <Th>Firstname</Th>
+                <Th>Lastname</Th>
+                <Th>Status</Th>
+                <Th>Role</Th>
+              </Tr>
             </Thead>
             <Tbody>
               <Tr>
@@ -376,10 +391,12 @@ export const WithCaption: ComponentStory<any> = (args) => {
           </Heading>
           <TableForStory aria-describedby={id} {...args}>
             <Thead>
-              <Th>Firstname</Th>
-              <Th>Lastname</Th>
-              <Th>Status</Th>
-              <Th>Role</Th>
+              <Tr>
+                <Th>Firstname</Th>
+                <Th>Lastname</Th>
+                <Th>Status</Th>
+                <Th>Role</Th>
+              </Tr>
             </Thead>
             <Tbody>
               <Tr>
@@ -419,5 +436,5 @@ export const WithCaption: ComponentStory<any> = (args) => {
         </div>
       </Flex>
     </>
-  )
-}
+  );
+};

--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -20,6 +20,9 @@ export const Th = styled('th', Label, {
   // override Label
   display: 'table-cell',
 
+  borderTopLeftRadius: 'inherit',
+  borderTopRightRadius: 'inherit',
+
   textAlign: 'start',
   p: '$2 $3',
   borderBottom: '1px solid $tableRowBorder',
@@ -50,6 +53,7 @@ export const Th = styled('th', Label, {
 export const Td = styled('td', {
   p: '$5 $3',
   borderBottom: '1px solid $tableRowBorder',
+  borderRadius: 'inherit',
   fontSize: '$3',
   lineHeight: '16px',
   variants: {
@@ -77,6 +81,9 @@ export const Td = styled('td', {
 });
 
 export const Tr = styled('tr', {
+  borderBottomLeftRadius: 'inherit',
+  borderBottomRightRadius: 'inherit',
+
   '&:hover': {
     color: '$tableHoverText',
   },
@@ -117,6 +124,8 @@ export const Tr = styled('tr', {
 
 export const Tfoot = styled('tfoot', {
   position: 'relative',
+  borderBottomLeftRadius: 'inherit',
+  borderBottomRightRadius: 'inherit',
 
   '&::after': {
     pointerEvents: 'none',
@@ -124,6 +133,7 @@ export const Tfoot = styled('tfoot', {
     position: 'absolute',
     inset: 0,
     backgroundColor: '$tableFooterLayerBackground',
+    borderRadius: 'inherit',
   },
 
   [`& ${Td}`]: {
@@ -137,6 +147,8 @@ export const Tfoot = styled('tfoot', {
 
 export const Thead = styled('thead', {
   position: 'relative',
+  borderTopLeftRadius: 'inherit',
+  borderTopRightRadius: 'inherit',
 
   '&::after': {
     pointerEvents: 'none',
@@ -144,6 +156,8 @@ export const Thead = styled('thead', {
     position: 'absolute',
     inset: 0,
     backgroundColor: '$tableHeaderLayerBackground',
+    borderTopLeftRadius: 'inherit',
+    borderTopRightRadius: 'inherit',
   },
 
   [`& ${Th}`]: {


### PR DESCRIPTION
Fixes the overlay `border-radius` for tables headers and footers.

Before:
![Screen Shot 2022-02-04 at 11 55 33](https://user-images.githubusercontent.com/38889364/152550485-374f90b2-81af-468b-91db-748054505887.png)

![Screen Shot 2022-02-04 at 11 55 38](https://user-images.githubusercontent.com/38889364/152550491-2beaccba-e810-4ff9-8442-cbc26c791e97.png)

After:
![Screen Shot 2022-02-04 at 11 55 15](https://user-images.githubusercontent.com/38889364/152550533-7c828826-a1d2-498a-9005-fee54d99bea5.png)

![Screen Shot 2022-02-04 at 11 55 20](https://user-images.githubusercontent.com/38889364/152550544-e57dafd9-9718-4720-86ad-47fd4f7978ac.png)

