### PR TITLE
fix: kill css incompatible error

### DIFF
--- a/components/Accordion/Accordion.stories.tsx
+++ b/components/Accordion/Accordion.stories.tsx
@@ -122,3 +122,22 @@ Complex.argTypes = {
     options: ['small', 'medium', 'large'],
   }
 }
+
+const Customize: ComponentStory<typeof AccordionForStory> = ({ size, ...args }) => (
+  <Box css={{ width: 300 }}>
+    <AccordionForStory css={{ maxWidth: 250 }} {...args}>
+      <AccordionItem css={{ bc: '$hiContrast' }} value="item-1">
+        <AccordionTrigger css={{ c: '$hiContrast' }} size={size}>Item1 Trigger</AccordionTrigger>
+        <AccordionContent css={{ c: '$hiContrast' }} size={size}>Item1 Content</AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="item-2">
+        <AccordionTrigger size={size}>Item2 Trigger</AccordionTrigger>
+        <AccordionContent size={size}>Item2 Content</AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="item-3">
+        <AccordionTrigger size={size}>Item3 Trigger</AccordionTrigger>
+        <AccordionContent size={size}>Item3 Content</AccordionContent>
+      </AccordionItem>
+    </AccordionForStory>
+  </Box>
+)

--- a/components/Accordion/Accordion.tsx
+++ b/components/Accordion/Accordion.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
-import { keyframes, styled, VariantProps } from '../../stitches.config';
+import { keyframes, styled, VariantProps, CSS } from '../../stitches.config';
 import { elevationVariants } from '../Elevation';
 import { ChevronRightIcon } from '@radix-ui/react-icons';
 
@@ -134,7 +134,7 @@ const StyledAccordionContentWrapper = styled('div', {
 // EXPORTS
 export const AccordionRoot = StyledAccordionRoot;
 export const AccordionItem = StyledAccordionItem;
-export type AccordionTriggerProps = VariantProps<typeof StyledAccordionTrigger> & {
+export type AccordionTriggerProps = React.ComponentProps<typeof StyledAccordionTrigger> & VariantProps<typeof StyledAccordionTrigger> & {
   children: React.ReactNode
 }
 export const AccordionTrigger = React.forwardRef<
@@ -147,8 +147,9 @@ export const AccordionTrigger = React.forwardRef<
     </StyledAccordionHeader>
   ));
 
-export type AccordionContentProps = VariantProps<typeof StyledAccordionContent> & VariantProps<typeof StyledAccordionContentWrapper> & {
+export type AccordionContentProps = VariantProps<typeof StyledAccordionContent> & Pick<VariantProps<typeof StyledAccordionContentWrapper>, 'size'> & {
   children: React.ReactNode
+  css?: CSS
 }
 export const AccordionContent = React.forwardRef<React.ElementRef<typeof StyledAccordionContent>, AccordionContentProps>(({ children, size, ...props }, forwardedRef) => (
   <StyledAccordionContent {...props} ref={forwardedRef}>

--- a/components/Alert/Alert.stories.tsx
+++ b/components/Alert/Alert.stories.tsx
@@ -14,7 +14,7 @@ export default {
 } as ComponentMeta<typeof AlertForStory>;
 
 export const Variants: ComponentStory<typeof AlertForStory> = (args) => (
-  <AlertForStory {...args}>
+  <Alert {...args}>
     <Heading size="2" css={{ mb: '$3' }}>
       Alert
     </Heading>
@@ -25,7 +25,7 @@ export const Variants: ComponentStory<typeof AlertForStory> = (args) => (
       voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
       non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     </Text>
-  </AlertForStory>
+  </Alert>
 );
 
 Variants.args = {
@@ -38,3 +38,19 @@ Variants.argTypes = {
     options: ['gray', 'info', 'success', 'warning', 'error'],
   },
 };
+
+
+const Customize: ComponentStory<typeof AlertForStory> = (args) => (
+  <Alert {...args} css={{ mt: '$1' }}>
+    <Heading size="2" css={{ mb: '$3' }}>
+      Alert
+    </Heading>
+    <Text css={{ mb: '$3' }}>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+      labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+      laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+      voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+      non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </Text>
+  </Alert>
+);

--- a/components/Alert/Alert.tsx
+++ b/components/Alert/Alert.tsx
@@ -1,5 +1,4 @@
-import { VariantProps } from '@stitches/react';
-import { styled } from '../../stitches.config';
+import { styled, VariantProps } from '../../stitches.config';
 import { Card } from '../Card';
 
 export const Alert = styled(Card, {

--- a/components/AriaTable/AriaTable.stories.tsx
+++ b/components/AriaTable/AriaTable.stories.tsx
@@ -1,7 +1,8 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import React from 'react';
-import { Table, TableProps, TableVariants, Tbody, Td, Th, Thead, Tr, Caption } from './AriaTable';
+import { Table, TableProps, TableVariants, Tbody, Td, Th, Thead, Tr, Caption, Tfoot } from './AriaTable';
 import { Badge } from '../Badge';
+import { Button } from '../Button';
 import { Card } from '../Card';
 import { UnstyledLink } from '../Link';
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
@@ -60,6 +61,19 @@ export const Basic: ComponentStory<any> = ({ transform, ...args }) => (
           <Td>Star wars</Td>
         </Tr>
       </Tbody>
+      <Tfoot>
+        <Tr>
+          <Td css={{ textAlign: 'center', columnSpan: 'all' }}>
+            <Button
+              ghost
+              variant="secondary"
+              css={{ fontSize: '$1', height: '$5', boxShadow: 'none' }}
+            >
+              Load more...
+            </Button>
+          </Td>
+        </Tr>
+      </Tfoot>
     </TableForStory>
   </Card>
 );
@@ -217,6 +231,69 @@ export const Links: ComponentStory<any> = (args) => (
           </UnstyledLink>
         </Tr>
       </Tbody>
+    </TableForStory>
+  </Card>
+)
+
+const Customize: ComponentStory<any> = (args) => (
+  <Card>
+    <TableForStory css={{ c: '$hiContrast' }} aria-label="People" aria-describedby="basic-table-caption" {...args}>
+      <Caption css={{ c: '$hiContrast' }} id="basic-table-caption">People with some information</Caption>
+      <Thead css={{ c: '$hiContrast' }}>
+        <Tr css={{ c: '$hiContrast' }}>
+          <Th css={{ c: '$hiContrast' }}>first name</Th>
+          <Th >last name</Th>
+          <Th >Status</Th>
+          <Th >Role</Th>
+        </Tr>
+      </Thead>
+      <Tbody css={{ c: '$hiContrast' }}>
+        <Tr>
+          <Td>John</Td>
+          <Td>Doe</Td>
+          <Td>
+            <Badge variant="green">Connected</Badge>
+          </Td>
+          <Td>Developer</Td>
+        </Tr>
+        <Tr>
+          <Td>Johny</Td>
+          <Td>Depp</Td>
+          <Td>
+            <Badge variant="orange">AFK</Badge>
+          </Td>
+          <Td>Actor</Td>
+        </Tr>
+        <Tr>
+          <Td>Natalie</Td>
+          <Td>Portman</Td>
+          <Td>
+            <Badge variant="green">Connected</Badge>
+          </Td>
+          <Td>Actor</Td>
+        </Tr>
+        <Tr>
+          <Td>Luke</Td>
+          <Td>Skywalker</Td>
+          <Td>
+            <Badge variant="red">Disconnected</Badge>
+          </Td>
+          <Td>Star wars</Td>
+        </Tr>
+      </Tbody>
+      <Tfoot css={{ c: '$hiContrast' }}>
+        <Tr>
+          <Td css={{ textAlign: 'center', columnSpan: 'all' }}>
+            <Button
+              ghost
+              variant="secondary"
+              css={{ fontSize: '$1', height: '$5', boxShadow: 'none' }}
+            >
+              Load more...
+            </Button>
+          </Td>
+        </Tr>
+      </Tfoot>
     </TableForStory>
   </Card>
 )

--- a/components/AriaTable/AriaTable.tsx
+++ b/components/AriaTable/AriaTable.tsx
@@ -1,6 +1,6 @@
 import React, { ComponentProps, ElementRef, forwardRef } from 'react';
 import { Slot } from '@radix-ui/react-slot';
-import { styled, VariantProps } from '../../stitches.config';
+import { styled, VariantProps, CSS } from '../../stitches.config';
 import { Caption as TableCaption, Tbody as TableTbody, Tfoot as TableTfoot, Tr as TableTr, Th as TableTh, Td as TableTd, Thead as TableThead, Table as TableTable } from '../Table';
 
 export const Caption = styled('div', TableCaption, {
@@ -10,14 +10,14 @@ export const Caption = styled('div', TableCaption, {
 const StyledTbody = styled('div', TableTbody, {
   display: 'table-row-group',
 });
-export const Tbody = forwardRef<ElementRef<typeof StyledTbody>, Omit<ComponentProps<typeof StyledTbody>, 'css'> & VariantProps<typeof StyledTbody>>((props, ref) => (
+export const Tbody = forwardRef<ElementRef<typeof StyledTbody>, Omit<ComponentProps<typeof StyledTbody>, 'css'> & VariantProps<typeof StyledTbody> & { css?: CSS }>((props, ref) => (
   <StyledTbody ref={ref} role="rowgroup" {...props} />
 ))
 
 const StyledTfoot = styled('div', TableTfoot, {
   display: 'table-footer-group',
 });
-export const Tfoot = forwardRef<ElementRef<typeof StyledTfoot>, Omit<ComponentProps<typeof StyledTfoot>, 'css'> & VariantProps<typeof StyledTfoot>>((props, ref) => (
+export const Tfoot = forwardRef<ElementRef<typeof StyledTfoot>, Omit<ComponentProps<typeof StyledTfoot>, 'css'> & VariantProps<typeof StyledTfoot> & { css?: CSS }>((props, ref) => (
   <StyledTfoot ref={ref} role="rowgroup" {...props} />
 ))
 
@@ -27,6 +27,7 @@ const StyledTr = styled('div', TableTr, {
 const StyledTrSlot = styled(Slot, StyledTr);
 export interface TrProps extends Omit<ComponentProps<typeof StyledTr>, 'css'>, VariantProps<typeof StyledTr> {
   asChild?: boolean
+  css?: CSS
 }
 export const Tr = forwardRef<ElementRef<typeof StyledTr>, TrProps>(({ asChild, ...props }, ref) => {
   const Component = asChild ? StyledTrSlot : StyledTr;
@@ -39,7 +40,7 @@ export const Tr = forwardRef<ElementRef<typeof StyledTr>, TrProps>(({ asChild, .
 const StyledTh = styled('span', TableTh, {
   display: 'table-cell'
 });
-export interface ThProps extends Omit<ComponentProps<typeof StyledTh>, 'css'>, VariantProps<typeof StyledTh> { }
+export interface ThProps extends Omit<ComponentProps<typeof StyledTh>, 'css'>, VariantProps<typeof StyledTh> { css?: CSS }
 export const Th = forwardRef<
   ElementRef<typeof StyledTh>,
   ThProps>((props, ref) => (
@@ -50,21 +51,21 @@ export const Th = forwardRef<
 const StyledTd = styled('span', TableTd, {
   display: 'table-cell',
 });
-export const Td = forwardRef<ElementRef<typeof StyledTd>, Omit<ComponentProps<typeof StyledTd>, 'css'> & VariantProps<typeof StyledTd>>((props, ref) => (
+export const Td = forwardRef<ElementRef<typeof StyledTd>, Omit<ComponentProps<typeof StyledTd>, 'css'> & VariantProps<typeof StyledTd> & VariantProps<typeof TableTd> & { css?: CSS }>((props, ref) => (
   <StyledTd ref={ref} role="cell" {...props} />
 ))
 
 const StyledThead = styled('div', TableThead, {
   display: 'table-header-group',
 });
-export const Thead = forwardRef<ElementRef<typeof StyledThead>, Omit<ComponentProps<typeof StyledThead>, 'css'> & VariantProps<typeof StyledThead>>((props, ref) => (
+export const Thead = forwardRef<ElementRef<typeof StyledThead>, Omit<ComponentProps<typeof StyledThead>, 'css'> & VariantProps<typeof StyledThead> & { css?: CSS }>((props, ref) => (
   <StyledThead ref={ref} role="rowgroup" {...props} />
 ))
 
 const StyledTable = styled('div', TableTable, {
   display: 'table',
 });
-export const Table = forwardRef<ElementRef<typeof StyledTable>, Omit<ComponentProps<typeof StyledTable>, 'css'> & VariantProps<typeof StyledTable>>((props, ref) => (
+export const Table = forwardRef<ElementRef<typeof StyledTable>, Omit<ComponentProps<typeof StyledTable>, 'css'> & VariantProps<typeof StyledTable> & { css?: CSS }>((props, ref) => (
   <StyledTable ref={ref} role="table" {...props} />
 ))
 

--- a/components/Avatar/Avatar.stories.tsx
+++ b/components/Avatar/Avatar.stories.tsx
@@ -89,3 +89,4 @@ Variants.argTypes = {
     options: ['gray', 'red', 'purple', 'blue', 'green', 'orange'],
   },
 };
+const Customize: ComponentStory<typeof Avatar> = (args) => <Avatar css={{ c: '$hiContrast' }} {...args} />;

--- a/components/Badge/Badge.stories.tsx
+++ b/components/Badge/Badge.stories.tsx
@@ -77,3 +77,7 @@ Interactive.args = {
   size: 'small',
   variant: 'gray',
 };
+
+const Customize: ComponentStory<typeof BadgeForStory> = (args) => (
+  <Badge css={{ c: '$hiContrast' }} {...args}>Customize</Badge>
+);

--- a/components/Badge/Badge.stories.tsx
+++ b/components/Badge/Badge.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import React from 'react';
-import { VariantProps } from '@stitches/react';
+import { VariantProps } from '../../stitches.config';
 import { Badge, COLORS } from './Badge';
 import { Flex } from '../Flex';
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';

--- a/components/Box/Box.stories.tsx
+++ b/components/Box/Box.stories.tsx
@@ -20,15 +20,11 @@ export default {
 } as ComponentMeta<typeof BoxForStory>;
 
 export const Basic: ComponentStory<typeof BoxForStory> = (args) => (
-  <BoxForStory {...args}>
+  <Box css={{ px: '$4', py: '$6', bc: '$deepBlue6', ta: 'center' }} {...args}>
     <Text as="p" size="4" css={{ lineHeight: '27px' }}>
       Traefik Labs develops the world's most popular cloud-native application networking software.
       It helps developers and operations teams of all sizes build, deploy and run modern
       microservices applications quickly and easily.
     </Text>
-  </BoxForStory>
+  </Box >
 );
-
-Basic.args = {
-  css: { px: '$4', py: '$6', bc: '$deepBlue6', ta: 'center' },
-};

--- a/components/Box/Box.stories.tsx
+++ b/components/Box/Box.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { VariantProps } from '@stitches/react';
+import { VariantProps } from '../../stitches.config';
 
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
 import { Box } from './Box';

--- a/components/Bubble/Bubble.stories.tsx
+++ b/components/Bubble/Bubble.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import { VariantProps } from '@stitches/react';
+import { VariantProps } from '../../stitches.config';
 import { Bubble } from './Bubble';
 import { Flex } from '../Flex';
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';

--- a/components/Bubble/Bubble.stories.tsx
+++ b/components/Bubble/Bubble.stories.tsx
@@ -66,3 +66,7 @@ Sizes.argTypes = {
     control: 'select',
   },
 };
+
+const Customize: ComponentStory<typeof BubbleForStory> = (args) => (
+  <Bubble {...args} css={{ c: '$hiContrast' }} />
+);

--- a/components/Button/Button.stories.tsx
+++ b/components/Button/Button.stories.tsx
@@ -86,3 +86,7 @@ export const Waiting = Template.bind({});
 Waiting.args = {
   state: 'waiting',
 };
+
+const Customize: ComponentStory<typeof ButtonForStory> = (args) => (
+  <ButtonForStory css={{ c: '$hiContrast' }} {...args}>Button</ButtonForStory>
+);

--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -1,6 +1,5 @@
-import { VariantProps } from '@stitches/react';
 import React from 'react';
-import { styled, keyframes, CSS } from '../../stitches.config';
+import { styled, keyframes, CSS, VariantProps } from '../../stitches.config';
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
 
 export const StyledButton = styled('button', {

--- a/components/Card/Card.stories.tsx
+++ b/components/Card/Card.stories.tsx
@@ -138,3 +138,7 @@ export const Elevation: ComponentStory<typeof Card> = (args) => (
 );
 
 Elevation.args = {};
+
+const Customize: ComponentStory<any> = (args) => (
+  <Card css={{ c: '$hiContrast' }} {...args}></Card>
+)

--- a/components/Checkbox/Checkbox.stories.tsx
+++ b/components/Checkbox/Checkbox.stories.tsx
@@ -35,3 +35,5 @@ Disabled.args = {
   checked: true,
   size: 'large',
 };
+
+const Customize: ComponentStory<typeof CheckboxForStory> = (args) => <CheckboxForStory css={{ c: '$hiContrast' }} {...args} />;

--- a/components/Container/Container.stories.tsx
+++ b/components/Container/Container.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { VariantProps } from '@stitches/react';
+import { VariantProps } from '../../stitches.config';
 
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
 import { Container } from './Container';

--- a/components/Container/Container.stories.tsx
+++ b/components/Container/Container.stories.tsx
@@ -21,7 +21,7 @@ export default {
 } as ComponentMeta<typeof ContainerForStory>;
 
 const Template: ComponentStory<typeof ContainerForStory> = (args) => (
-  <ContainerForStory {...args} css={{ bc: '$deepBlue3' }}>
+  <Container {...args} css={{ bc: '$deepBlue3' }}>
     <Paragraph>
       Lorem ipsum, dolor sit amet consectetur adipisicing elit. Quo, iste. Perferendis saepe aperiam
       repudiandae, a ea labore error iure! Doloribus sunt earum, aperiam facilis ex corporis veniam
@@ -32,7 +32,7 @@ const Template: ComponentStory<typeof ContainerForStory> = (args) => (
       minus error dolorem? Explicabo iure quidem, maxime fugit quos obcaecati, molestiae nemo nobis
       aliquid saepe, impedit at.
     </Paragraph>
-  </ContainerForStory>
+  </Container>
 );
 
 export const Basic = Template.bind({});

--- a/components/Dialog/Dialog.stories.tsx
+++ b/components/Dialog/Dialog.stories.tsx
@@ -63,3 +63,32 @@ export const Basic: ComponentStory<any> = (args) => {
     </Dialog>
   );
 };
+
+const Customize: ComponentStory<any> = (args) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => setOpen(isOpen)}>
+      <DialogTrigger asChild>
+        <Button onClick={() => setOpen(true)}>Open dialog</Button>
+      </DialogTrigger>
+
+      <Box>
+        {[...Array(10)].map((_, i) => (
+          <Text key={i} css={{ my: '$1' }}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+            exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+            dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+            mollit anim id est laborum.
+          </Text>
+        ))}
+      </Box>
+
+      <DialogContent css={{ c: '$hiContrast' }}>
+        <Content />
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -60,3 +60,29 @@ export const DefaultOpen = Template.bind({});
 DefaultOpen.args = {
   defaultOpen: true,
 };
+
+const Customize: ComponentStory<typeof DropdownMenu> = (args) => (
+  <DropdownMenu  {...args}>
+    <DropdownMenuTrigger asChild>
+      <Button>Dropdown</Button>
+    </DropdownMenuTrigger>
+    <DropdownMenuContent css={{ c: '$hiContrast' }} align="end">
+      <DropdownMenuGroup css={{ c: '$hiContrast' }}>
+        <DropdownMenuItem css={{ c: '$hiContrast' }}>Item</DropdownMenuItem>
+        <DropdownMenuItem>Item</DropdownMenuItem>
+        <DropdownMenuItem>Item</DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuCheckboxItem css={{ c: '$hiContrast' }}>Item</DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem checked>Item</DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem>Item</DropdownMenuCheckboxItem>
+        <DropdownMenuSeparator css={{ c: '$hiContrast' }} />
+        <DropdownMenuLabel css={{ c: '$hiContrast' }}>Choose one</DropdownMenuLabel>
+        <DropdownMenuRadioGroup css={{ c: '$hiContrast' }} value="one">
+          <DropdownMenuRadioItem value="one" css={{ c: '$hiContrast' }}>Item</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="two">Item</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="three">Item</DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+      </DropdownMenuGroup>
+    </DropdownMenuContent>
+  </DropdownMenu>
+);

--- a/components/Elevation/Elevation.stories.tsx
+++ b/components/Elevation/Elevation.stories.tsx
@@ -76,3 +76,7 @@ Basic.argTypes = {
     options: [0, 1, 2, 3, 4, 5],
   },
 };
+
+const Customize: ComponentStory<typeof Elevation> = () => (
+  <Elevation css={{ c: '$hiContrast' }} variant={0} />
+)

--- a/components/Flex/Flex.stories.tsx
+++ b/components/Flex/Flex.stories.tsx
@@ -22,3 +22,7 @@ Basic.args = {
   align: 'center',
   gap: '6',
 };
+
+const Customize: ComponentStory<typeof Flex> = (args) => (
+  <Flex {...args} css={{ c: '$hiContrast' }} />
+)

--- a/components/Flex/Flex.tsx
+++ b/components/Flex/Flex.tsx
@@ -1,6 +1,4 @@
-import { VariantProps } from '@stitches/react';
 import { styled } from '../../stitches.config';
-import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
 
 export const Flex = styled('div', {
   boxSizing: 'border-box',

--- a/components/Grid/Grid.stories.tsx
+++ b/components/Grid/Grid.stories.tsx
@@ -40,3 +40,7 @@ Basic.args = {
   columns: '3',
   gap: '6',
 };
+
+const Customize: ComponentStory<typeof Grid> = (args) => (
+  <Grid {...args} css={{ c: '$hiContrast' }} />
+)

--- a/components/Grid/Grid.tsx
+++ b/components/Grid/Grid.tsx
@@ -1,6 +1,4 @@
-import { VariantProps } from '@stitches/react';
 import { styled } from '../../stitches.config';
-import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
 
 export const Grid = styled('div', {
   boxSizing: 'border-box',

--- a/components/Heading/Heading.stories.tsx
+++ b/components/Heading/Heading.stories.tsx
@@ -30,6 +30,6 @@ export const Size: ComponentStory<typeof HeadingForStory> = ({ size, ...args }) 
   </>
 );
 
-export const Customize: ComponentStory<typeof HeadingForStory> = (args) => (
+const Customize: ComponentStory<typeof HeadingForStory> = (args) => (
   <HeadingForStory css={{ fontWeight: '$semiBold' }} {...args}>SemiBold</HeadingForStory>
 );

--- a/components/Heading/Heading.stories.tsx
+++ b/components/Heading/Heading.stories.tsx
@@ -14,7 +14,7 @@ export default {
 } as ComponentMeta<typeof HeadingForStory>;
 
 const Template: ComponentStory<typeof HeadingForStory> = (args) => (
-  <HeadingForStory {...args}>Title {args?.size}</HeadingForStory>
+  <HeadingForStory  {...args}>Title {args?.size}</HeadingForStory>
 );
 
 export const Basic = Template.bind({});
@@ -28,4 +28,8 @@ export const Size: ComponentStory<typeof HeadingForStory> = ({ size, ...args }) 
     <Template {...args} size="3" />
     <Template {...args} size="4" />
   </>
+);
+
+export const Customize: ComponentStory<typeof HeadingForStory> = (args) => (
+  <HeadingForStory css={{ fontWeight: '$semiBold' }} {...args}>SemiBold</HeadingForStory>
 );

--- a/components/Heading/Heading.stories.tsx
+++ b/components/Heading/Heading.stories.tsx
@@ -14,7 +14,7 @@ export default {
 } as ComponentMeta<typeof HeadingForStory>;
 
 const Template: ComponentStory<typeof HeadingForStory> = (args) => (
-  <HeadingForStory  {...args}>Title {args?.size}</HeadingForStory>
+  <HeadingForStory {...args}>Title {args?.size}</HeadingForStory>
 );
 
 export const Basic = Template.bind({});

--- a/components/Heading/Heading.tsx
+++ b/components/Heading/Heading.tsx
@@ -13,7 +13,7 @@ export type HeadingVariants = { size?: HeadingSizeVariants } & Omit<
   'size'
 >;
 export type HeadingProps = React.ComponentProps<typeof DEFAULT_TAG> &
-  HeadingVariants & { as?: any };
+  HeadingVariants & { as?: any, css?: CSS };
 
 export const Heading = React.forwardRef<React.ElementRef<typeof DEFAULT_TAG>, HeadingProps>(
   // '2' here is the default heading size variant

--- a/components/IconButton/IconButton.stories.tsx
+++ b/components/IconButton/IconButton.stories.tsx
@@ -74,3 +74,7 @@ Variants.argTypes = {
     control: 'boolean',
   },
 };
+
+const Customize: ComponentStory<any> = (args) => (
+  <IconButton css={{ c: '$hiContrast' }} {...args} size="1"></IconButton>
+)

--- a/components/IconButton/IconButton.tsx
+++ b/components/IconButton/IconButton.tsx
@@ -1,5 +1,4 @@
-import { VariantProps } from '@stitches/react';
-import { styled } from '../../stitches.config';
+import { styled, VariantProps } from '../../stitches.config';
 
 export const IconButton = styled('button', {
   // Reset

--- a/components/Image/Image.stories.tsx
+++ b/components/Image/Image.stories.tsx
@@ -21,3 +21,5 @@ export const Large = Template.bind({});
 Large.args = {
   src: 'https://picsum.photos/2000/3000',
 };
+
+const Customize: ComponentStory<typeof Image> = (args) => <Image css={{ c: '$hiContrast' }} {...args} />;

--- a/components/Image/Image.tsx
+++ b/components/Image/Image.tsx
@@ -1,6 +1,4 @@
-import { VariantProps } from '@stitches/react';
 import { styled } from '../../stitches.config';
-import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
 
 export const Image = styled('img', {
   // Reset

--- a/components/Input/Input.stories.tsx
+++ b/components/Input/Input.stories.tsx
@@ -260,3 +260,7 @@ export const Autofill: ComponentStory<typeof InputForStory> = (args) => (
     </Flex>
   </form>
 );
+
+const Customize: ComponentStory<typeof InputForStory> = ({ id, ...args }) => (
+  <InputForStory css={{ c: '$hiContrast' }} {...args} />
+)

--- a/components/Input/Input.tsx
+++ b/components/Input/Input.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { VariantProps } from '@stitches/react';
-import { styled, CSS } from '../../stitches.config';
+import { styled, CSS, VariantProps } from '../../stitches.config';
 import { elevationVariants } from '../Elevation';
 
 // CONSTANTS

--- a/components/Label/Label.stories.tsx
+++ b/components/Label/Label.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { VariantProps } from '@stitches/react';
+import { VariantProps } from '../../stitches.config';
 
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
 import { Label } from './Label';

--- a/components/Label/Label.stories.tsx
+++ b/components/Label/Label.stories.tsx
@@ -23,9 +23,9 @@ export default {
 
 const Template: ComponentStory<typeof LabelForStory> = ({ id, ...args }) => (
   <Box>
-    <LabelForStory htmlFor={id} css={{ mr: '$2' }} {...args}>
+    <Label htmlFor={id} css={{ mr: '$2' }} {...args}>
       Email field
-    </LabelForStory>
+    </Label>
     <input id={id} name="email" type="email" />
   </Box>
 );
@@ -68,9 +68,9 @@ ignoreArgType('id', Invalid);
 
 export const Disabled: ComponentStory<typeof LabelForStory> = ({ id, ...args }) => (
   <Box>
-    <LabelForStory htmlFor={id} css={{ mr: '$2' }} variant="subtle" {...args}>
+    <Label htmlFor={id} css={{ mr: '$2' }} variant="subtle" {...args}>
       Email field
-    </LabelForStory>
+    </Label>
     <input id={id} name="email" type="email" disabled />
   </Box>
 );
@@ -92,9 +92,9 @@ export const FocusContrast: ComponentStory<typeof LabelForStory> = ({ id, ...arg
 
   return (
     <Box>
-      <LabelForStory variant={hasFocus ? 'contrast' : 'default'} htmlFor={id} css={{ mr: '$2' }} {...args}>
+      <Label variant={hasFocus ? 'contrast' : 'default'} htmlFor={id} css={{ mr: '$2' }} {...args}>
         Email field
-      </LabelForStory>
+      </Label>
       <input id={id} name="email" type="email" onFocus={onFocus} onBlur={onBlur} />
     </Box>
   );

--- a/components/Link/Link.stories.tsx
+++ b/components/Link/Link.stories.tsx
@@ -1,6 +1,6 @@
 import React, { LinkHTMLAttributes } from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { VariantProps } from '@stitches/react';
+import { VariantProps } from '../../stitches.config';
 
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
 import { Link } from './Link';

--- a/components/Link/Link.stories.tsx
+++ b/components/Link/Link.stories.tsx
@@ -33,3 +33,9 @@ export const Variant = Template.bind({});
 Variant.args = {
   variant: 'primary',
 };
+
+const Customize: ComponentStory<typeof LinkForStory> = (args) => (
+  <Link css={{ c: '$hiContraqt' }} href="https://traefik.io" {...args}>
+    https://traefik.io
+  </Link>
+);

--- a/components/Navigation/Navigation.stories.tsx
+++ b/components/Navigation/Navigation.stories.tsx
@@ -129,7 +129,7 @@ const MultipleSectionsTemplate: ComponentStory<typeof NavigationDrawerForStory> 
         <Text>Company Logo</Text>
       </NavigationContainer>
       <NavigationContainer css={{ flexGrow: 1 }}>
-        <NavigationItem {...navigationHandlerProps('/')} startAdornment={<DashboardIcon />}>
+        <NavigationItem css={{ c: '$hiContrast' }} {...navigationHandlerProps('/')} startAdornment={<DashboardIcon />}>
           Dashboard
         </NavigationItem>
         <NavigationItem {...navigationHandlerProps('/profile')} startAdornment={<PersonIcon />}>

--- a/components/Navigation/Navigation.tsx
+++ b/components/Navigation/Navigation.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, ReactNode } from 'react';
-import { styled, css, VariantProps } from '../../stitches.config';
+import { styled, css, CSS, VariantProps } from '../../stitches.config';
 import { elevationVariants } from '../Elevation';
 import { Flex } from '../Flex';
 
@@ -159,6 +159,7 @@ export type NavigationItemProps = {
   endAdornment?: ReactNode;
   children: ReactNode;
   href?: string;
+  css?: CSS
 } & StyledLinkVariants &
   StyledButtonVariants;
 

--- a/components/Popover/Popover.tsx
+++ b/components/Popover/Popover.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { styled, CSS } from '../../stitches.config';
+import { styled, CSS, VariantProps } from '../../stitches.config';
 import * as PopoverPrimitive from '@radix-ui/react-popover';
 import { Box } from '../Box';
 import { panelStyles } from '../Panel';
-import { VariantProps } from '@stitches/react';
 import { elevationVariants } from '../Elevation';
 
 export type PopoverProps = React.ComponentProps<typeof PopoverPrimitive.Root> & {

--- a/components/Radio/Radio.stories.tsx
+++ b/components/Radio/Radio.stories.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { VariantProps } from '@stitches/react';
+import { VariantProps } from '../../stitches.config';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Radio, RadioVariants, RadioProps, RadioGroup } from './Radio';
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
-import { type } from 'os';
 
 const BaseRadio = (props: RadioProps): JSX.Element => <Radio {...props} />;
 const RadioForStory = modifyVariantsForStory<RadioVariants, RadioProps>(BaseRadio);

--- a/components/Radio/Radio.stories.tsx
+++ b/components/Radio/Radio.stories.tsx
@@ -45,3 +45,10 @@ Disabled.args = {
   disabled: true,
   size: 2,
 };
+
+const Customize: ComponentStory<typeof RadioForStory> = ({ value, ...args }) => (
+  <RadioGroup css={{ c: '$hiContrast' }} defaultValue="1">
+    <RadioForStory value="1" css={{ mr: '$5' }} {...args} />
+    <RadioForStory value="2" css={{ mr: '$5' }} {...args} />
+  </RadioGroup>
+);

--- a/components/RadioAccordion/RadioAccordion.stories.tsx
+++ b/components/RadioAccordion/RadioAccordion.stories.tsx
@@ -27,3 +27,22 @@ export const Basic: ComponentStory<typeof RadioAccordionRoot> = (args) => (
     </RadioAccordionRoot>
   </Box>
 );
+
+const Customize: ComponentStory<typeof RadioAccordionRoot> = (args) => (
+  <Box css={{ width: 300 }}>
+    <RadioAccordionRoot {...args} css={{ bc: '$red9' }}>
+      <RadioAccordionItem value="item-1" css={{ bc: '$red9' }}>
+        <RadioAccordionTrigger css={{ bc: '$red9' }}>Item1 Trigger</RadioAccordionTrigger>
+        <RadioAccordionContent css={{ bc: '$red9' }}>Item1 Content</RadioAccordionContent>
+      </RadioAccordionItem>
+      <RadioAccordionItem value="item-2">
+        <RadioAccordionTrigger >Item2 Trigger</RadioAccordionTrigger>
+        <RadioAccordionContent >Item2 Content</RadioAccordionContent>
+      </RadioAccordionItem>
+      <RadioAccordionItem value="item-3">
+        <RadioAccordionTrigger >Item3 Trigger</RadioAccordionTrigger>
+        <RadioAccordionContent >Item3 Content</RadioAccordionContent>
+      </RadioAccordionItem>
+    </RadioAccordionRoot>
+  </Box>
+);

--- a/components/RadioAccordion/RadioAccordion.tsx
+++ b/components/RadioAccordion/RadioAccordion.tsx
@@ -12,7 +12,7 @@ export const RadioAccordionRoot: (props: RadioAccordionRootProps) => JSX.Element
 export const RadioAccordionItem = React.forwardRef<React.ElementRef<typeof AccordionItem>, ComponentProps<typeof AccordionItem>>(({ value, children, ...props }, forwardedRef) => {
 
   return (
-    <AccordionItem value={value} ref={forwardedRef} css={{ display: 'inherit', flexDirection: 'column' } as any} {...props}>
+    <AccordionItem value={value} ref={forwardedRef} css={{ display: 'inherit', flexDirection: 'column' }} {...props}>
       {children}
     </AccordionItem>
   );

--- a/components/RadioAccordion/RadioAccordion.tsx
+++ b/components/RadioAccordion/RadioAccordion.tsx
@@ -1,15 +1,17 @@
 import React, { ComponentProps } from "react";
-import { styled, VariantProps } from "../../stitches.config";
+import { styled, VariantProps, CSS } from "../../stitches.config";
 import { StyledAccordionTrigger, StyledAccordionHeader, AccordionRoot, AccordionContent, AccordionItem, AccordionTriggerProps } from "../Accordion";
 import { INDICATOR_BASE_STYLES, RADIO_BASE_STYLES } from "../Radio";
 import type { AccordionSingleProps } from '@radix-ui/react-accordion'
 
-export interface RadioAccordionRootProps extends Omit<AccordionSingleProps, 'type' | 'collapsible' | 'css'>, Omit<VariantProps<typeof AccordionRoot>, 'type' | 'collapsible'> { }
+export interface RadioAccordionRootProps extends Omit<AccordionSingleProps, 'type' | 'collapsible' | 'css'>, Omit<VariantProps<typeof AccordionRoot>, 'type' | 'collapsible'> { css?: CSS }
 
 export const RadioAccordionRoot: (props: RadioAccordionRootProps) => JSX.Element = (props) => (
   <AccordionRoot {...props} type="single" collapsible={false} />
 )
-export const RadioAccordionItem = React.forwardRef<React.ElementRef<typeof AccordionItem>, ComponentProps<typeof AccordionItem>>(({ value, children, ...props }, forwardedRef) => {
+
+export interface RadioAccordionItemProps extends Omit<ComponentProps<typeof AccordionItem>, 'css'>, VariantProps<typeof AccordionItem> { css?: CSS }
+export const RadioAccordionItem = React.forwardRef<React.ElementRef<typeof AccordionItem>, RadioAccordionItemProps>(({ value, children, ...props }, forwardedRef) => {
 
   return (
     <AccordionItem value={value} ref={forwardedRef} css={{ display: 'inherit', flexDirection: 'column' }} {...props}>
@@ -46,8 +48,9 @@ const StyledRadioAccordionTrigger = styled(StyledAccordionTrigger, {
   }
 })
 
+export interface RadioAccordionTriggerProps extends AccordionTriggerProps { }
 export const RadioAccordionTrigger = React.forwardRef<
-  React.ElementRef<typeof StyledRadioAccordionTrigger>, AccordionTriggerProps>(({ children, ...props }, ref) => {
+  React.ElementRef<typeof StyledRadioAccordionTrigger>, RadioAccordionTriggerProps>(({ children, ...props }, ref) => {
 
     return (
       <StyledAccordionHeader>

--- a/components/Select/Select.stories.tsx
+++ b/components/Select/Select.stories.tsx
@@ -66,3 +66,13 @@ Overflow.argTypes = {
     control: 'number'
   }
 }
+
+const Customize: ComponentStory<typeof SelectForStory> = (args) => (
+  <Select css={{ c: '$hiContrast' }} {...args}>
+    <option value="option1">Option 1</option>
+    <option value="option2">Option 2</option>
+    <option value="option3">Option 3</option>
+    <option value="option4">Option 4</option>
+    <option value="option5">Option 5</option>
+  </Select>
+);

--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { styled, CSS } from '../../stitches.config';
+import { styled, CSS, VariantProps } from '../../stitches.config';
 import { CaretSortIcon } from '@radix-ui/react-icons';
-import { VariantProps } from '@stitches/react';
 import { elevationVariants } from '../Elevation';
 
 // CONSTANTS

--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -236,7 +236,7 @@ export const Select = React.forwardRef<React.ElementRef<typeof StyledSelect>, Se
   ({ css, size, state, variant, cursor, ...props }, forwardedRef) => {
     return (
       <SelectWrapper
-        css={css as any}
+        css={css}
         size={size}
         state={state}
         variant={variant}

--- a/components/Skeleton/Skeleton.tsx
+++ b/components/Skeleton/Skeleton.tsx
@@ -1,5 +1,4 @@
-import { keyframes, styled } from '../../stitches.config';
-import { VariantProps } from '@stitches/react';
+import { keyframes, styled, VariantProps } from '../../stitches.config';
 
 const pulse = keyframes({
   '0%': { opacity: 0 },

--- a/components/Switch/Switch.stories.tsx
+++ b/components/Switch/Switch.stories.tsx
@@ -112,3 +112,5 @@ LabelAndTitle.args = {
   disabled: false,
 }
 ignoreArgType('id', LabelAndTitle);
+
+const Customize: ComponentStory<typeof SwitchForStory> = (args) => <SwitchForStory css={{ c: '$hiContrast' }} {...args} />;

--- a/components/Table/Table.stories.tsx
+++ b/components/Table/Table.stories.tsx
@@ -438,3 +438,56 @@ export const WithCaption: ComponentStory<any> = (args) => {
     </>
   );
 };
+
+
+const Customize: ComponentStory<any> = (args) => (
+  <TableForStory css={{ c: '$hiContrast' }} {...args}>
+    <Thead css={{ c: '$hiContrast' }}>
+      <Tr css={{ c: '$hiContrast' }}>
+        <Th css={{ c: '$hiContrast' }}>Firstname</Th>
+        <Th>Lastname</Th>
+        <Th>Status</Th>
+        <Th>Role</Th>
+      </Tr>
+    </Thead>
+    <Tbody css={{ c: '$hiContrast' }}>
+      <Tr css={{ c: '$hiContrast' }}>
+        <Td css={{ c: '$hiContrast' }}>John</Td>
+        <Td>Doe</Td>
+        <Td>
+          <Badge variant="green">Connected</Badge>
+        </Td>
+        <Td>Developer</Td>
+      </Tr>
+      <Tr>
+        <Td>Johny</Td>
+        <Td>Depp</Td>
+        <Td>
+          <Badge variant="orange">AFK</Badge>
+        </Td>
+        <Td>Actor</Td>
+      </Tr>
+      <Tr>
+        <Td>Natalie</Td>
+        <Td>Portman</Td>
+        <Td>
+          <Badge variant="green">Connected</Badge>
+        </Td>
+        <Td>Actor</Td>
+      </Tr>
+      <Tr>
+        <Td>Luke</Td>
+        <Td>Skywalker</Td>
+        <Td>
+          <Badge variant="red">Disconnected</Badge>
+        </Td>
+        <Td>Star wars</Td>
+      </Tr>
+    </Tbody>
+    <Tfoot css={{ c: '$hiContrast' }}>
+      <Tr>
+        <Td colSpan={4}>Footer information</Td>
+      </Tr>
+    </Tfoot>
+  </TableForStory>
+);

--- a/components/Text/Text.stories.tsx
+++ b/components/Text/Text.stories.tsx
@@ -104,6 +104,6 @@ export const Size: ComponentStory<typeof TextForStory> = ({ size, ...args }) => 
   </>
 );
 
-export const Customize: ComponentStory<typeof TextForStory> = (args) => (
+const Customize: ComponentStory<typeof TextForStory> = (args) => (
   <TextForStory css={{ fontWeight: '$semiBold' }} {...args}>SemiBold</TextForStory>
 );

--- a/components/Text/Text.stories.tsx
+++ b/components/Text/Text.stories.tsx
@@ -103,3 +103,7 @@ export const Size: ComponentStory<typeof TextForStory> = ({ size, ...args }) => 
     </TextForStory>
   </>
 );
+
+export const Customize: ComponentStory<typeof TextForStory> = (args) => (
+  <TextForStory css={{ fontWeight: '$semiBold' }} {...args}>SemiBold</TextForStory>
+);

--- a/components/Text/Text.tsx
+++ b/components/Text/Text.tsx
@@ -1,5 +1,4 @@
-import { VariantProps } from '@stitches/react';
-import { styled } from '../../stitches.config';
+import { styled, CSS, VariantProps } from '../../stitches.config';
 
 export const Text = styled('span', {
   // Reset
@@ -105,4 +104,4 @@ export const Text = styled('span', {
 });
 
 export type TextVariants = VariantProps<typeof Text>;
-export type TextProps = TextVariants & {};
+export type TextProps = TextVariants & { css?: CSS };

--- a/components/TextField/TextField.stories.tsx
+++ b/components/TextField/TextField.stories.tsx
@@ -197,3 +197,8 @@ LabelComponent.args = {
   label: label,
 }
 ignoreArgType('id', LabelComponent);
+
+
+const Customize: ComponentStory<typeof TextFieldForStory> = (args) => (
+  <TextFieldForStory css={{ c: '$hiContrast' }} {...args} />
+);

--- a/components/Textarea/Textarea.stories.tsx
+++ b/components/Textarea/Textarea.stories.tsx
@@ -90,3 +90,8 @@ export const Ghost: ComponentStory<typeof TextareaForStory> = (args) => (
   </Flex>
 );
 Ghost.args = { defaultValue: 'default value', variant: 'ghost', rows: 2 };
+
+
+const Customize: ComponentStory<typeof TextareaForStory> = (args) => (
+  <Textarea {...args} css={{ c: '$hiContrast' }} />
+);

--- a/components/Textarea/Textarea.tsx
+++ b/components/Textarea/Textarea.tsx
@@ -263,14 +263,14 @@ export const Textarea = React.forwardRef<React.ElementRef<typeof StyledTextarea>
     );
 
     return (
-      <Box css={rootCss as any}>
+      <Box css={rootCss}>
         {label && (
           <Label variant={labelVariant} htmlFor={id} css={{ display: 'block' }}>
             {label}
           </Label>
         )}
         <TextareaWrapper state={state} disabled={disabled}>
-          <StyledTextarea id={id} ref={forwardedRef} css={css as any}
+          <StyledTextarea id={id} ref={forwardedRef} css={css}
             disabled={disabled}
             state={state}
             onFocus={handleFocus} onBlur={handleBlur}

--- a/components/Tooltip/Tooltip.stories.tsx
+++ b/components/Tooltip/Tooltip.stories.tsx
@@ -80,3 +80,12 @@ NodeContent.argTypes = {
     },
   },
 };
+
+
+const Customize: ComponentStory<typeof TooltipForStory> = (args) => (
+  <Container>
+    <TooltipForStory css={{ c: '$hiContrast' }} {...args}>
+      <Text css={{ display: 'inline-block' }}>Tooltip label</Text>
+    </TooltipForStory>
+  </Container>
+);

--- a/components/Tooltip/Tooltip.tsx
+++ b/components/Tooltip/Tooltip.tsx
@@ -49,7 +49,7 @@ export function Tooltip({
       <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
 
       <Content
-        css={css as any}
+        css={css}
         side="top"
         align="center"
         sideOffset={5}
@@ -62,7 +62,7 @@ export function Tooltip({
             as="p"
             css={{
               color: 'currentColor',
-              lineHeight: multiline ? '20px' : (undefined as any),
+              lineHeight: multiline ? '20px' : undefined,
             }}
           >
             {content}

--- a/components/Tooltip/Tooltip.tsx
+++ b/components/Tooltip/Tooltip.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { VariantProps, CSS } from '@stitches/react';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 
-import { styled } from '../../stitches.config';
+import { styled, CSS, VariantProps } from '../../stitches.config';
 import { Text } from '../Text';
 import { Box } from '../Box';
 

--- a/tsconfig-rollup.json
+++ b/tsconfig-rollup.json
@@ -13,8 +13,23 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es5"
+    "target": "es5",
+    "paths": {
+      "@emotion/core": [
+        "./types/index.d.ts"
+      ],
+      "@storybook/theming": [
+        "./types/index.d.ts"
+      ]
+    }
   },
-  "exclude": ["node_modules", "pages"],
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]
+  "exclude": [
+    "node_modules",
+    "pages"
+  ],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,10 +15,29 @@
     "strict": true,
     "target": "es5",
     "noImplicitAny": false,
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "paths": {
+      "@emotion/core": [
+        "./types.d.ts"
+      ],
+      "@storybook/theming": [
+        "./types.d.ts"
+      ]
+    }
   },
-  "exclude": ["node_modules", "pages"],
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]
+  "exclude": [
+    "node_modules",
+    "pages"
+  ],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,10 +24,10 @@
     "isolatedModules": true,
     "paths": {
       "@emotion/core": [
-        "./types.d.ts"
+        "./types/index.d.ts"
       ],
       "@storybook/theming": [
-        "./types.d.ts"
+        "./types/index.d.ts"
       ]
     }
   },


### PR DESCRIPTION
# Description

Closes #293 

Applies solutions from related issue on stitches.

# How to test

`Textarea.stories.tsx` had typing issues. I'm taking this one as example, but this PR should fix all `css` typing issues in the project. It would be awesome to validate that point with more use cases.

EDIT: I just added stories for `Text` and `Heading` showing that we can add `css` prop to those components :tada: 

1. Try opening the file without changes applied by my PR. Check you have typescript lint issues in the file
2. Checkout my PR, make sure you restart you IDE in-between (close/reopen)
3. Check you no longer have typescript lint issues in the file

# Preview

https://user-images.githubusercontent.com/3367393/154343211-da51ec58-e84d-490c-b567-37b3ada16249.mp4


