### PR TITLE
chore: release v1.0.0-13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@traefiklabs/faency",
-  "version": "1.0.0-12",
+  "version": "1.0.0-13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@traefiklabs/faency",
-      "version": "1.0.0-12",
+      "version": "1.0.0-13",
       "dependencies": {
         "@radix-ui/colors": "0.1.7",
         "@radix-ui/react-accordion": "0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@traefiklabs/faency",
   "description": "Traefik Labs design system",
-  "version": "1.0.0-12",
+  "version": "1.0.0-13",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
   "files": [


### PR DESCRIPTION
# [Commits since last release](https://github.com/traefik/faency/commits/master)

![image](https://user-images.githubusercontent.com/3367393/156152015-be48f2b2-bd0d-446b-9ee1-1a56c415c600.png)


# Breaking changes

## `Skeleton`

###  Some variants no longer exist

- `avatarX` variants (1 to 6)
- `title`
- `heading`

### Usage change

Recommended usage can be found in skeleton stories