### PR TITLE
fix: popover arrow color not customizable

### DIFF
--- a/components/Popover/Popover.stories.tsx
+++ b/components/Popover/Popover.stories.tsx
@@ -74,8 +74,8 @@ export const IconTrigger: ComponentStory<typeof PopoverForStory> = (args) => (
           <HamburgerMenuIcon />
         </Button>
       </PopoverTrigger>
-      <PopoverContent arrowCss={{ color: '$primary' }} css={{ bc: '$primary', p: '$2' }}>
-        <Text css={{ c: 'white' }}>Content</Text>
+      <PopoverContent arrowCss={{ fill: '$primary' }} css={{ bc: '$primary', p: '$2' }}>
+        <Text css={{ c: '$loContrast' }}>Content</Text>
       </PopoverContent>
     </PopoverForStory>
   </Container>
@@ -95,8 +95,8 @@ export const RowAnchor: ComponentStory<typeof PopoverForStory> = (args) => (
           to open the anchor
         </Box>
       </PopoverAnchor>
-      <PopoverContent arrowCss={{ color: '$primary' }} css={{ bc: '$primary', p: '$2' }}>
-        <Text css={{ c: 'white' }}>Content</Text>
+      <PopoverContent arrowCss={{ fill: '$primary' }} css={{ bc: '$primary', p: '$2' }}>
+        <Text css={{ c: '$loContrast' }}>Content</Text>
       </PopoverContent>
     </PopoverForStory>
   </Container>

--- a/components/Popover/Popover.stories.tsx
+++ b/components/Popover/Popover.stories.tsx
@@ -14,6 +14,7 @@ import { Container } from '../Container';
 import { Button } from '../Button';
 import { Text } from '../Text';
 import { Flex } from '../Flex';
+import { HamburgerMenuIcon } from '@radix-ui/react-icons';
 
 const BasePopover = (props: PopoverProps): JSX.Element => <Popover {...props} />;
 const PopoverForStory = modifyVariantsForStory<PopoverVariants, PopoverProps>(BasePopover);
@@ -58,6 +59,21 @@ export const RichContent: ComponentStory<typeof PopoverForStory> = (args) => (
             <Button variant="primary">Close</Button>
           </PopoverClose>
         </Flex>
+      </PopoverContent>
+    </PopoverForStory>
+  </Container>
+);
+
+export const IconTrigger: ComponentStory<typeof PopoverForStory> = (args) => (
+  <Container>
+    <PopoverForStory {...args}>
+      <PopoverTrigger asChild>
+        <Button size="small">
+          <HamburgerMenuIcon />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent arrowCss={{ color: '$primary' }} css={{ bc: '$primary', p: '$2' }}>
+        <Text css={{ c: 'white' }}>Content</Text>
       </PopoverContent>
     </PopoverForStory>
   </Container>

--- a/components/Popover/Popover.stories.tsx
+++ b/components/Popover/Popover.stories.tsx
@@ -15,6 +15,8 @@ import { Button } from '../Button';
 import { Text } from '../Text';
 import { Flex } from '../Flex';
 import { HamburgerMenuIcon } from '@radix-ui/react-icons';
+import { PopoverAnchor } from '@radix-ui/react-popover';
+import { Box } from '../Box';
 
 const BasePopover = (props: PopoverProps): JSX.Element => <Popover {...props} />;
 const PopoverForStory = modifyVariantsForStory<PopoverVariants, PopoverProps>(BasePopover);
@@ -72,6 +74,27 @@ export const IconTrigger: ComponentStory<typeof PopoverForStory> = (args) => (
           <HamburgerMenuIcon />
         </Button>
       </PopoverTrigger>
+      <PopoverContent arrowCss={{ color: '$primary' }} css={{ bc: '$primary', p: '$2' }}>
+        <Text css={{ c: 'white' }}>Content</Text>
+      </PopoverContent>
+    </PopoverForStory>
+  </Container>
+);
+
+export const RowAnchor: ComponentStory<typeof PopoverForStory> = (args) => (
+  <Container>
+    <PopoverForStory {...args}>
+      <PopoverAnchor asChild>
+        <Box css={{ bc: '$orange4', p: '$2', display: 'inline-block' }}>
+          Click on
+          <PopoverTrigger asChild>
+            <Button size="small" css={{ mx: '$2' }}>
+              <HamburgerMenuIcon />
+            </Button>
+          </PopoverTrigger>
+          to open the anchor
+        </Box>
+      </PopoverAnchor>
       <PopoverContent arrowCss={{ color: '$primary' }} css={{ bc: '$primary', p: '$2' }}>
         <Text css={{ c: 'white' }}>Content</Text>
       </PopoverContent>

--- a/components/Popover/Popover.stories.tsx
+++ b/components/Popover/Popover.stories.tsx
@@ -85,7 +85,7 @@ export const RowAnchor: ComponentStory<typeof PopoverForStory> = (args) => (
   <Container>
     <PopoverForStory {...args}>
       <PopoverAnchor asChild>
-        <Box css={{ bc: '$orange4', p: '$2', display: 'inline-block' }}>
+        <Box css={{ bc: '$01dp', p: '$2', display: 'inline-block', c: '$hiContrast' }}>
           Click on
           <PopoverTrigger asChild>
             <Button size="small" css={{ mx: '$2' }}>

--- a/components/Popover/Popover.tsx
+++ b/components/Popover/Popover.tsx
@@ -30,6 +30,10 @@ const StyledContent = styled(PopoverPrimitive.Content, panelStyles, {
   },
 });
 
+const StyledArrow = styled(PopoverPrimitive.Arrow, {
+  fill: 'currentColor',
+});
+
 type PopoverContentPrimitiveProps = Omit<
   React.ComponentProps<typeof PopoverPrimitive.Content>,
   'as'
@@ -46,13 +50,10 @@ export const PopoverContent = React.forwardRef<
 >(({ children, hideArrow, arrowCss, ...props }, fowardedRef) => (
   <StyledContent sideOffset={0} {...props} ref={fowardedRef}>
     {children}
-    {!hideArrow && (
-      <Box css={arrowCss}>
-        <PopoverPrimitive.Arrow width={11} height={5} offset={5} style={{ fill: 'currentColor' }} />
-      </Box>
-    )}
+    {!hideArrow && <StyledArrow width={11} height={5} offset={5} css={arrowCss} />}
   </StyledContent>
 ));
 
 export const PopoverTrigger = PopoverPrimitive.Trigger;
 export const PopoverClose = PopoverPrimitive.Close;
+export const PopoverAnchor = PopoverPrimitive.Anchor;

--- a/components/Popover/Popover.tsx
+++ b/components/Popover/Popover.tsx
@@ -37,16 +37,17 @@ type PopoverContentPrimitiveProps = Omit<
 export type PopoverContentProps = PopoverContentPrimitiveProps & {
   css?: CSS;
   hideArrow?: boolean;
+  arrowCss?: CSS;
 };
 
 export const PopoverContent = React.forwardRef<
   React.ElementRef<typeof StyledContent>,
   PopoverContentProps
->(({ children, hideArrow, ...props }, fowardedRef) => (
+>(({ children, hideArrow, arrowCss, ...props }, fowardedRef) => (
   <StyledContent sideOffset={0} {...props} ref={fowardedRef}>
     {children}
     {!hideArrow && (
-      <Box css={{ color: '$deepBlue3' }}>
+      <Box css={arrowCss}>
         <PopoverPrimitive.Arrow width={11} height={5} offset={5} style={{ fill: 'currentColor' }} />
       </Box>
     )}

--- a/components/Popover/Popover.tsx
+++ b/components/Popover/Popover.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { styled, CSS, VariantProps } from '../../stitches.config';
 import * as PopoverPrimitive from '@radix-ui/react-popover';
-import { Box } from '../Box';
 import { panelStyles } from '../Panel';
 import { elevationVariants } from '../Elevation';
 
@@ -30,27 +29,57 @@ const StyledContent = styled(PopoverPrimitive.Content, panelStyles, {
   },
 });
 
+const fillColorVariants: Record<number, CSS> = {
+  0: {
+    fill: '$00dp',
+  },
+  1: {
+    fill: '$01dp',
+  },
+  2: {
+    fill: '$02dp',
+  },
+  3: {
+    fill: '$03dp',
+  },
+  4: {
+    fill: '$04dp',
+  },
+  5: {
+    fill: '$05dp',
+  },
+};
+
 const StyledArrow = styled(PopoverPrimitive.Arrow, {
   fill: 'currentColor',
+  variants: {
+    elevation: fillColorVariants,
+  },
+  defaultVariants: {
+    elevation: 2,
+  },
 });
 
 type PopoverContentPrimitiveProps = Omit<
   React.ComponentProps<typeof PopoverPrimitive.Content>,
   'as'
 >;
-export type PopoverContentProps = PopoverContentPrimitiveProps & {
-  css?: CSS;
-  hideArrow?: boolean;
-  arrowCss?: CSS;
-};
+export type PopoverContentProps = PopoverContentPrimitiveProps &
+  VariantProps<typeof StyledContent> & {
+    css?: CSS;
+    hideArrow?: boolean;
+    arrowCss?: CSS;
+  };
 
 export const PopoverContent = React.forwardRef<
   React.ElementRef<typeof StyledContent>,
   PopoverContentProps
->(({ children, hideArrow, arrowCss, ...props }, fowardedRef) => (
-  <StyledContent sideOffset={0} {...props} ref={fowardedRef}>
+>(({ children, hideArrow, arrowCss, elevation, ...props }, fowardedRef) => (
+  <StyledContent sideOffset={0} elevation={elevation} {...props} ref={fowardedRef}>
     {children}
-    {!hideArrow && <StyledArrow width={11} height={5} offset={5} css={arrowCss} />}
+    {!hideArrow && (
+      <StyledArrow elevation={elevation} width={11} height={5} offset={5} css={arrowCss} />
+    )}
   </StyledContent>
 ));
 

--- a/index.ts
+++ b/index.ts
@@ -50,7 +50,7 @@ export {
   NavigationLink,
 } from './components/Navigation';
 export { Overlay } from './components/Overlay';
-export { Popover, PopoverClose, PopoverContent, PopoverTrigger } from './components/Popover';
+export { Popover, PopoverClose, PopoverContent, PopoverTrigger, PopoverAnchor } from './components/Popover';
 export { Portal } from '@radix-ui/react-portal';
 export { Radio, RadioGroup } from './components/Radio';
 export { Select } from './components/Select';


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Description

<!--
Link the issue and give some description of the implementation
For any issue on Github solved by this PR, please use the closing keywords, e.g. Closes #number or Fixes #number
-->

Closes #315 

- Popover arrow customizable
- also export [PopoverAnchor primitive](https://www.radix-ui.com/docs/primitives/components/popover#anchor)
- adds stories

## Good PR checkboxes

- [x] Change has been tested
- [ ] Added/Updated tests
- [x] Added/Updated stories
- [x] PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
- [x] Labels are set
- [x] Project is linked

## Good Review checkboxes

<details>
<summary> ℹ️  Copy the snippet and paste in the review field to fill it</summary>

```markdown
- [ ] I've tested the changes
- [ ] I've agreed on the unit tests (soon to come)
- [ ] I've checked the stories
- [ ] I've read the code and understood it
- [ ] I don't have any more questions
- [ ] I've described any optional improvements
- [ ] I checked PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
```

</details>
