### PR TITLE
feat!: dialog export content without close icon

### DIFF
--- a/components/Dialog/Dialog.stories.tsx
+++ b/components/Dialog/Dialog.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import { Dialog, DialogContent, DialogTrigger, DialogClose } from './Dialog';
+import { Dialog, DialogContent, DialogTrigger, StyledContent } from './Dialog';
 import { Text } from '../Text';
 import { useState } from 'react';
 import { Button } from '../Button';
@@ -89,6 +89,35 @@ const Customize: ComponentStory<any> = (args) => {
       <DialogContent css={{ c: '$hiContrast' }}>
         <Content />
       </DialogContent>
+    </Dialog>
+  );
+};
+
+export const NoCloseIcon: ComponentStory<any> = (args) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => setOpen(isOpen)}>
+      <DialogTrigger asChild>
+        <Button onClick={() => setOpen(true)}>Open dialog</Button>
+      </DialogTrigger>
+
+      <Box>
+        {[...Array(10)].map((_, i) => (
+          <Text key={i} css={{ my: '$1' }}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+            exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+            dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+            mollit anim id est laborum.
+          </Text>
+        ))}
+      </Box>
+
+      <StyledContent>
+        <Content />
+      </StyledContent>
     </Dialog>
   );
 };

--- a/components/Dialog/Dialog.tsx
+++ b/components/Dialog/Dialog.tsx
@@ -28,7 +28,7 @@ export function Dialog({ children, ...props }: DialogProps) {
   );
 }
 
-const StyledContent = styled(DialogPrimitive.Content, Card, {
+export const StyledContent = styled(DialogPrimitive.Content, Card, {
   position: 'fixed',
   top: '50%',
   left: '50%',
@@ -84,4 +84,4 @@ export const DialogContent = React.forwardRef<
 ));
 
 export const DialogTrigger = DialogPrimitive.Trigger;
-export const DialogClose = DialogPrimitive.Close;
+export const DialogClose = StyledCloseButton;

--- a/index.ts
+++ b/index.ts
@@ -21,7 +21,7 @@ export { Checkbox } from './components/Checkbox';
 export { Container } from './components/Container';
 export { Elevation, elevationVariants } from './components/Elevation';
 export { FaencyProvider } from './components/FaencyProvider';
-export { Dialog, DialogClose, DialogContent, DialogTrigger } from './components/Dialog';
+export { Dialog, DialogClose, DialogContent, StyledContent, DialogTrigger } from './components/Dialog';
 export {
   DropdownMenu,
   DropdownMenuTrigger,


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Description

<!--
Link the issue and give some description of the implementation
For any issue on Github solved by this PR, please use the closing keywords, e.g. Closes #number or Fixes #number
-->

We have use cases for dialogs which cannot be closed.

Adds export of dialog's content without the close button for easier composition towards that end.

## Breaking changes

- `DialogClose` component is now the styled version of the primitive

## Good PR checkboxes

- [x] Change has been tested
- [ ] Added/Updated tests
- [x] Added/Updated stories
- [x] PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
- [x] Labels are set
- [x] Project is linked

## Good Review checkboxes

<details>
<summary> ℹ️  Copy the snippet and paste in the review field to fill it</summary>

```markdown
- [ ] I've tested the changes
- [ ] I've agreed on the unit tests (soon to come)
- [ ] I've checked the stories
- [ ] I've read the code and understood it
- [ ] I don't have any more questions
- [ ] I've described any optional improvements
- [ ] I checked PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
```

</details>
