### PR TITLE
feat: aria table colspan

### DIFF
--- a/components/AriaTable/AriaTable.stories.tsx
+++ b/components/AriaTable/AriaTable.stories.tsx
@@ -1,6 +1,17 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import React from 'react';
-import { Table, TableProps, TableVariants, Tbody, Td, Th, Thead, Tr, Caption, Tfoot } from './AriaTable';
+import {
+  Table,
+  TableProps,
+  TableVariants,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  Caption,
+  Tfoot,
+} from './AriaTable';
 import { Badge } from '../Badge';
 import { Button } from '../Button';
 import { Card } from '../Card';
@@ -63,7 +74,7 @@ export const Basic: ComponentStory<any> = ({ transform, ...args }) => (
       </Tbody>
       <Tfoot>
         <Tr>
-          <Td css={{ textAlign: 'center', columnSpan: 'all' }}>
+          <Td colSpan={4} css={{ textAlign: 'center' }}>
             <Button
               ghost
               variant="secondary"
@@ -90,7 +101,7 @@ Basic.argTypes = {
       capitalizeWords: 'capitalizeWords',
       uppercase: 'uppercase',
       none: '',
-    }
+    },
   },
 };
 
@@ -233,18 +244,25 @@ export const Links: ComponentStory<any> = (args) => (
       </Tbody>
     </TableForStory>
   </Card>
-)
+);
 
 const Customize: ComponentStory<any> = (args) => (
   <Card>
-    <TableForStory css={{ c: '$hiContrast' }} aria-label="People" aria-describedby="basic-table-caption" {...args}>
-      <Caption css={{ c: '$hiContrast' }} id="basic-table-caption">People with some information</Caption>
+    <TableForStory
+      css={{ c: '$hiContrast' }}
+      aria-label="People"
+      aria-describedby="basic-table-caption"
+      {...args}
+    >
+      <Caption css={{ c: '$hiContrast' }} id="basic-table-caption">
+        People with some information
+      </Caption>
       <Thead css={{ c: '$hiContrast' }}>
         <Tr css={{ c: '$hiContrast' }}>
           <Th css={{ c: '$hiContrast' }}>first name</Th>
-          <Th >last name</Th>
-          <Th >Status</Th>
-          <Th >Role</Th>
+          <Th>last name</Th>
+          <Th>Status</Th>
+          <Th>Role</Th>
         </Tr>
       </Thead>
       <Tbody css={{ c: '$hiContrast' }}>
@@ -283,7 +301,7 @@ const Customize: ComponentStory<any> = (args) => (
       </Tbody>
       <Tfoot css={{ c: '$hiContrast' }}>
         <Tr>
-          <Td css={{ textAlign: 'center', columnSpan: 'all' }}>
+          <Td css={{ textAlign: 'center' }}>
             <Button
               ghost
               variant="secondary"
@@ -296,4 +314,65 @@ const Customize: ComponentStory<any> = (args) => (
       </Tfoot>
     </TableForStory>
   </Card>
-)
+);
+
+export const Columns: ComponentStory<any> = ({ transform, ...args }) => (
+  <TableForStory aria-label="People" aria-describedby="basic-table-caption" {...args}>
+    <Caption id="basic-table-caption">People with some information</Caption>
+    <Thead>
+      <Tr>
+        <Th transform={transform}>first name</Th>
+        <Th transform={transform}>last name</Th>
+        <Th transform={transform}>Status</Th>
+        <Th transform={transform}>Role</Th>
+      </Tr>
+    </Thead>
+    <Tbody>
+      <Tr>
+        <Td>John</Td>
+        <Td>Doe</Td>
+        <Td>
+          <Badge variant="green">Connected</Badge>
+        </Td>
+        <Td>Developer</Td>
+      </Tr>
+      <Tr>
+        <Td>Johny</Td>
+        <Td>Depp</Td>
+        <Td>
+          <Badge variant="orange">AFK</Badge>
+        </Td>
+        <Td>Actor</Td>
+      </Tr>
+      <Tr>
+        <Td>Natalie</Td>
+        <Td>Portman</Td>
+        <Td>
+          <Badge variant="green">Connected</Badge>
+        </Td>
+        <Td>Actor</Td>
+      </Tr>
+      <Tr>
+        <Td>Luke</Td>
+        <Td>Skywalker</Td>
+        <Td>
+          <Badge variant="red">Disconnected</Badge>
+        </Td>
+        <Td>Star wars</Td>
+      </Tr>
+    </Tbody>
+    <Tfoot>
+      <Tr>
+        <Td colSpan={4} css={{ textAlign: 'center' }}>
+          <Button
+            ghost
+            variant="secondary"
+            css={{ fontSize: '$1', height: '$5', boxShadow: 'none' }}
+          >
+            Load more...
+          </Button>
+        </Td>
+      </Tr>
+    </Tfoot>
+  </TableForStory>
+);

--- a/components/AriaTable/AriaTable.stories.tsx
+++ b/components/AriaTable/AriaTable.stories.tsx
@@ -75,7 +75,7 @@ export const Basic: ComponentStory<any> = ({ transform, ...args }) => (
     </Tbody>
     <Tfoot>
       <Tr>
-        <Td colSpan={4} css={{ textAlign: 'center' }}>
+        <Td fullColSpan css={{ textAlign: 'center' }}>
           <Button
             ghost
             variant="secondary"
@@ -358,7 +358,7 @@ export const Columns: ComponentStory<any> = ({ transform, ...args }) => (
       </Tbody>
       <Tfoot>
         <Tr>
-          <Td colSpan={4} css={{ textAlign: 'center' }}>
+          <Td fullColSpan css={{ textAlign: 'center' }}>
             <Button
               ghost
               variant="secondary"
@@ -452,6 +452,71 @@ export const Columns: ComponentStory<any> = ({ transform, ...args }) => (
               css={{ fontSize: '$1', height: '$5', boxShadow: 'none' }}
             >
               Four
+            </Button>
+          </Td>
+        </Tr>
+      </Tfoot>
+    </TableForStory>
+    <TableForStory
+      css={{ tableLayout: 'auto' }}
+      aria-label="People"
+      aria-describedby="basic-table-caption"
+      {...args}
+    >
+      <Caption size="10" id="basic-table-caption">
+        People with some information
+      </Caption>
+      <Thead>
+        <Tr>
+          <Th transform={transform}>first name</Th>
+          <Th transform={transform}>last name</Th>
+          <Th transform={transform}>Status</Th>
+          <Th transform={transform}>Role</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        <Tr>
+          <Td>John</Td>
+          <Td>Doe</Td>
+          <Td>
+            <Badge variant="green">Connected</Badge>
+          </Td>
+          <Td>Developer</Td>
+        </Tr>
+        <Tr>
+          <Td>Johny</Td>
+          <Td>Depp</Td>
+          <Td>
+            <Badge variant="orange">AFK</Badge>
+          </Td>
+          <Td>Actor</Td>
+        </Tr>
+        <Tr>
+          <Td>Natalie</Td>
+          <Td>Portman</Td>
+          <Td>
+            <Badge variant="green">Connected</Badge>
+          </Td>
+          <Td>Actor</Td>
+        </Tr>
+        <Tr>
+          <Td>Luke</Td>
+          <Td>Skywalker</Td>
+          <Td>
+            <Badge variant="red">Disconnected</Badge>
+          </Td>
+          <Td>Star wars</Td>
+        </Tr>
+      </Tbody>
+      <Tfoot>
+        <Tr>
+          <Td fullColSpan css={{ textAlign: 'center' }}>
+            <Button
+              ghost
+              variant="secondary"
+              css={{ fontSize: '$1', height: '$5', boxShadow: 'none' }}
+            >
+              Load more...
             </Button>
           </Td>
         </Tr>

--- a/components/AriaTable/AriaTable.stories.tsx
+++ b/components/AriaTable/AriaTable.stories.tsx
@@ -75,7 +75,7 @@ export const Basic: ComponentStory<any> = ({ transform, ...args }) => (
     </Tbody>
     <Tfoot>
       <Tr>
-        <Td fullColSpan css={{ textAlign: 'center' }}>
+        <Td fullColSpan aria-colspan={4} css={{ textAlign: 'center' }}>
           <Button
             ghost
             variant="secondary"
@@ -358,7 +358,7 @@ export const Columns: ComponentStory<any> = ({ transform, ...args }) => (
       </Tbody>
       <Tfoot>
         <Tr>
-          <Td fullColSpan css={{ textAlign: 'center' }}>
+          <Td fullColSpan aria-colspan={4} css={{ textAlign: 'center' }}>
             <Button
               ghost
               variant="secondary"
@@ -510,7 +510,7 @@ export const Columns: ComponentStory<any> = ({ transform, ...args }) => (
       </Tbody>
       <Tfoot>
         <Tr>
-          <Td fullColSpan css={{ textAlign: 'center' }}>
+          <Td fullColSpan aria-colspan={4} css={{ textAlign: 'center' }}>
             <Button
               ghost
               variant="secondary"

--- a/components/AriaTable/AriaTable.stories.tsx
+++ b/components/AriaTable/AriaTable.stories.tsx
@@ -14,7 +14,6 @@ import {
 } from './AriaTable';
 import { Badge } from '../Badge';
 import { Button } from '../Button';
-import { Card } from '../Card';
 import { UnstyledLink } from '../Link';
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
 
@@ -27,66 +26,66 @@ export default {
 } as ComponentMeta<typeof TableForStory>;
 
 export const Basic: ComponentStory<any> = ({ transform, ...args }) => (
-  <Card>
-    <TableForStory aria-label="People" aria-describedby="basic-table-caption" {...args}>
-      <Caption id="basic-table-caption">People with some information</Caption>
-      <Thead>
-        <Tr>
-          <Th transform={transform}>first name</Th>
-          <Th transform={transform}>last name</Th>
-          <Th transform={transform}>Status</Th>
-          <Th transform={transform}>Role</Th>
-        </Tr>
-      </Thead>
-      <Tbody>
-        <Tr>
-          <Td>John</Td>
-          <Td>Doe</Td>
-          <Td>
-            <Badge variant="green">Connected</Badge>
-          </Td>
-          <Td>Developer</Td>
-        </Tr>
-        <Tr>
-          <Td>Johny</Td>
-          <Td>Depp</Td>
-          <Td>
-            <Badge variant="orange">AFK</Badge>
-          </Td>
-          <Td>Actor</Td>
-        </Tr>
-        <Tr>
-          <Td>Natalie</Td>
-          <Td>Portman</Td>
-          <Td>
-            <Badge variant="green">Connected</Badge>
-          </Td>
-          <Td>Actor</Td>
-        </Tr>
-        <Tr>
-          <Td>Luke</Td>
-          <Td>Skywalker</Td>
-          <Td>
-            <Badge variant="red">Disconnected</Badge>
-          </Td>
-          <Td>Star wars</Td>
-        </Tr>
-      </Tbody>
-      <Tfoot>
-        <Tr>
-          <Td colSpan={4} css={{ textAlign: 'center' }}>
-            <Button
-              ghost
-              variant="secondary"
-              css={{ fontSize: '$1', height: '$5', boxShadow: 'none' }}
-            >
-              Load more...
-            </Button>
-          </Td>
-        </Tr>
-      </Tfoot>
-    </TableForStory>
-  </Card>
+  <TableForStory aria-label="People" aria-describedby="basic-table-caption" {...args}>
+    <Caption id="basic-table-caption" size="10">
+      People with some information
+    </Caption>
+    <Thead>
+      <Tr>
+        <Th transform={transform}>first name</Th>
+        <Th transform={transform}>last name</Th>
+        <Th transform={transform}>Status</Th>
+        <Th transform={transform}>Role</Th>
+      </Tr>
+    </Thead>
+    <Tbody>
+      <Tr>
+        <Td>John</Td>
+        <Td>Doe</Td>
+        <Td>
+          <Badge variant="green">Connected</Badge>
+        </Td>
+        <Td>Developer</Td>
+      </Tr>
+      <Tr>
+        <Td>Johny</Td>
+        <Td>Depp</Td>
+        <Td>
+          <Badge variant="orange">AFK</Badge>
+        </Td>
+        <Td>Actor</Td>
+      </Tr>
+      <Tr>
+        <Td>Natalie</Td>
+        <Td>Portman</Td>
+        <Td>
+          <Badge variant="green">Connected</Badge>
+        </Td>
+        <Td>Actor</Td>
+      </Tr>
+      <Tr>
+        <Td>Luke</Td>
+        <Td>Skywalker</Td>
+        <Td>
+          <Badge variant="red">Disconnected</Badge>
+        </Td>
+        <Td>Star wars</Td>
+      </Tr>
+    </Tbody>
+    <Tfoot>
+      <Tr>
+        <Td colSpan={4} css={{ textAlign: 'center' }}>
+          <Button
+            ghost
+            variant="secondary"
+            css={{ fontSize: '$1', height: '$5', boxShadow: 'none' }}
+          >
+            Load more...
+          </Button>
+        </Td>
+      </Tr>
+    </Tfoot>
+  </TableForStory>
 );
 
 Basic.args = {
@@ -106,52 +105,50 @@ Basic.argTypes = {
 };
 
 export const Alignment: ComponentStory<any> = (args) => (
-  <Card>
-    <TableForStory>
-      <Thead>
-        <Tr>
-          <Th {...args}>Firstname</Th>
-          <Th {...args}>Lastname</Th>
-          <Th {...args}>Status</Th>
-          <Th {...args}>Role</Th>
-        </Tr>
-      </Thead>
-      <Tbody>
-        <Tr>
-          <Td {...args}>John</Td>
-          <Td {...args}>Doe</Td>
-          <Td {...args}>
-            <Badge variant="green">Connected</Badge>
-          </Td>
-          <Td {...args}>Developer</Td>
-        </Tr>
-        <Tr>
-          <Td {...args}>Johny</Td>
-          <Td {...args}>Depp</Td>
-          <Td {...args}>
-            <Badge variant="orange">AFK</Badge>
-          </Td>
-          <Td {...args}>Actor</Td>
-        </Tr>
-        <Tr>
-          <Td {...args}>Natalie</Td>
-          <Td {...args}>Portman</Td>
-          <Td {...args}>
-            <Badge variant="green">Connected</Badge>
-          </Td>
-          <Td {...args}>Actor</Td>
-        </Tr>
-        <Tr>
-          <Td {...args}>Luke</Td>
-          <Td {...args}>Skywalker</Td>
-          <Td {...args}>
-            <Badge variant="red">Disconnected</Badge>
-          </Td>
-          <Td {...args}>Star wars</Td>
-        </Tr>
-      </Tbody>
-    </TableForStory>
-  </Card>
+  <TableForStory>
+    <Thead>
+      <Tr>
+        <Th {...args}>Firstname</Th>
+        <Th {...args}>Lastname</Th>
+        <Th {...args}>Status</Th>
+        <Th {...args}>Role</Th>
+      </Tr>
+    </Thead>
+    <Tbody>
+      <Tr>
+        <Td {...args}>John</Td>
+        <Td {...args}>Doe</Td>
+        <Td {...args}>
+          <Badge variant="green">Connected</Badge>
+        </Td>
+        <Td {...args}>Developer</Td>
+      </Tr>
+      <Tr>
+        <Td {...args}>Johny</Td>
+        <Td {...args}>Depp</Td>
+        <Td {...args}>
+          <Badge variant="orange">AFK</Badge>
+        </Td>
+        <Td {...args}>Actor</Td>
+      </Tr>
+      <Tr>
+        <Td {...args}>Natalie</Td>
+        <Td {...args}>Portman</Td>
+        <Td {...args}>
+          <Badge variant="green">Connected</Badge>
+        </Td>
+        <Td {...args}>Actor</Td>
+      </Tr>
+      <Tr>
+        <Td {...args}>Luke</Td>
+        <Td {...args}>Skywalker</Td>
+        <Td {...args}>
+          <Badge variant="red">Disconnected</Badge>
+        </Td>
+        <Td {...args}>Star wars</Td>
+      </Tr>
+    </Tbody>
+  </TableForStory>
 );
 
 Alignment.argTypes = {
@@ -166,52 +163,50 @@ Alignment.args = {
 };
 
 export const Interactive: ComponentStory<any> = (args) => (
-  <Card>
-    <TableForStory>
-      <Thead>
-        <Tr>
-          <Th>Firstname</Th>
-          <Th>Lastname</Th>
-          <Th>Status</Th>
-          <Th>Role</Th>
-        </Tr>
-      </Thead>
-      <Tbody>
-        <Tr {...args}>
-          <Td>John</Td>
-          <Td>Doe</Td>
-          <Td>
-            <Badge variant="green">Connected</Badge>
-          </Td>
-          <Td>Developer</Td>
-        </Tr>
-        <Tr {...args}>
-          <Td>Johny</Td>
-          <Td>Depp</Td>
-          <Td>
-            <Badge variant="orange">AFK</Badge>
-          </Td>
-          <Td>Actor</Td>
-        </Tr>
-        <Tr {...args} active>
-          <Td>Natalie</Td>
-          <Td>Portman</Td>
-          <Td>
-            <Badge variant="green">Connected</Badge>
-          </Td>
-          <Td>Actor</Td>
-        </Tr>
-        <Tr {...args}>
-          <Td>Luke</Td>
-          <Td>Skywalker</Td>
-          <Td>
-            <Badge variant="red">Disconnected</Badge>
-          </Td>
-          <Td>Star Wars</Td>
-        </Tr>
-      </Tbody>
-    </TableForStory>
-  </Card>
+  <TableForStory>
+    <Thead>
+      <Tr>
+        <Th>Firstname</Th>
+        <Th>Lastname</Th>
+        <Th>Status</Th>
+        <Th>Role</Th>
+      </Tr>
+    </Thead>
+    <Tbody>
+      <Tr {...args}>
+        <Td>John</Td>
+        <Td>Doe</Td>
+        <Td>
+          <Badge variant="green">Connected</Badge>
+        </Td>
+        <Td>Developer</Td>
+      </Tr>
+      <Tr {...args}>
+        <Td>Johny</Td>
+        <Td>Depp</Td>
+        <Td>
+          <Badge variant="orange">AFK</Badge>
+        </Td>
+        <Td>Actor</Td>
+      </Tr>
+      <Tr {...args} active>
+        <Td>Natalie</Td>
+        <Td>Portman</Td>
+        <Td>
+          <Badge variant="green">Connected</Badge>
+        </Td>
+        <Td>Actor</Td>
+      </Tr>
+      <Tr {...args}>
+        <Td>Luke</Td>
+        <Td>Skywalker</Td>
+        <Td>
+          <Badge variant="red">Disconnected</Badge>
+        </Td>
+        <Td>Star Wars</Td>
+      </Tr>
+    </Tbody>
+  </TableForStory>
 );
 
 Interactive.args = {
@@ -219,101 +214,97 @@ Interactive.args = {
 };
 
 export const Links: ComponentStory<any> = (args) => (
-  <Card>
-    <TableForStory aria-label="Empty" aria-describedby="empty-table-caption" {...args}>
-      <Caption id="empty-table-caption">Table with empty data</Caption>
-      <Thead>
-        <Tr>
-          <Th>first name</Th>
-          <Th>last name</Th>
-          <Th>Status</Th>
-          <Th>Role</Th>
-        </Tr>
-      </Thead>
-      <Tbody>
-        <Tr interactive asChild>
-          <UnstyledLink href="https://traefik.io">
-            <Td>John</Td>
-            <Td>Doe</Td>
-            <Td>
-              <Badge variant="green">Connected</Badge>
-            </Td>
-            <Td>Developer</Td>
-          </UnstyledLink>
-        </Tr>
-      </Tbody>
-    </TableForStory>
-  </Card>
-);
-
-const Customize: ComponentStory<any> = (args) => (
-  <Card>
-    <TableForStory
-      css={{ c: '$hiContrast' }}
-      aria-label="People"
-      aria-describedby="basic-table-caption"
-      {...args}
-    >
-      <Caption css={{ c: '$hiContrast' }} id="basic-table-caption">
-        People with some information
-      </Caption>
-      <Thead css={{ c: '$hiContrast' }}>
-        <Tr css={{ c: '$hiContrast' }}>
-          <Th css={{ c: '$hiContrast' }}>first name</Th>
-          <Th>last name</Th>
-          <Th>Status</Th>
-          <Th>Role</Th>
-        </Tr>
-      </Thead>
-      <Tbody css={{ c: '$hiContrast' }}>
-        <Tr>
+  <TableForStory aria-label="Empty" aria-describedby="empty-table-caption" {...args}>
+    <Caption id="empty-table-caption">Table with empty data</Caption>
+    <Thead>
+      <Tr>
+        <Th>first name</Th>
+        <Th>last name</Th>
+        <Th>Status</Th>
+        <Th>Role</Th>
+      </Tr>
+    </Thead>
+    <Tbody>
+      <Tr interactive asChild>
+        <UnstyledLink href="https://traefik.io">
           <Td>John</Td>
           <Td>Doe</Td>
           <Td>
             <Badge variant="green">Connected</Badge>
           </Td>
           <Td>Developer</Td>
-        </Tr>
-        <Tr>
-          <Td>Johny</Td>
-          <Td>Depp</Td>
-          <Td>
-            <Badge variant="orange">AFK</Badge>
-          </Td>
-          <Td>Actor</Td>
-        </Tr>
-        <Tr>
-          <Td>Natalie</Td>
-          <Td>Portman</Td>
-          <Td>
-            <Badge variant="green">Connected</Badge>
-          </Td>
-          <Td>Actor</Td>
-        </Tr>
-        <Tr>
-          <Td>Luke</Td>
-          <Td>Skywalker</Td>
-          <Td>
-            <Badge variant="red">Disconnected</Badge>
-          </Td>
-          <Td>Star wars</Td>
-        </Tr>
-      </Tbody>
-      <Tfoot css={{ c: '$hiContrast' }}>
-        <Tr>
-          <Td css={{ textAlign: 'center' }}>
-            <Button
-              ghost
-              variant="secondary"
-              css={{ fontSize: '$1', height: '$5', boxShadow: 'none' }}
-            >
-              Load more...
-            </Button>
-          </Td>
-        </Tr>
-      </Tfoot>
-    </TableForStory>
-  </Card>
+        </UnstyledLink>
+      </Tr>
+    </Tbody>
+  </TableForStory>
+);
+
+const Customize: ComponentStory<any> = (args) => (
+  <TableForStory
+    css={{ c: '$hiContrast' }}
+    aria-label="People"
+    aria-describedby="basic-table-caption"
+    {...args}
+  >
+    <Caption css={{ c: '$hiContrast' }} id="basic-table-caption">
+      People with some information
+    </Caption>
+    <Thead css={{ c: '$hiContrast' }}>
+      <Tr css={{ c: '$hiContrast' }}>
+        <Th css={{ c: '$hiContrast' }}>first name</Th>
+        <Th>last name</Th>
+        <Th>Status</Th>
+        <Th>Role</Th>
+      </Tr>
+    </Thead>
+    <Tbody css={{ c: '$hiContrast' }}>
+      <Tr>
+        <Td>John</Td>
+        <Td>Doe</Td>
+        <Td>
+          <Badge variant="green">Connected</Badge>
+        </Td>
+        <Td>Developer</Td>
+      </Tr>
+      <Tr>
+        <Td>Johny</Td>
+        <Td>Depp</Td>
+        <Td>
+          <Badge variant="orange">AFK</Badge>
+        </Td>
+        <Td>Actor</Td>
+      </Tr>
+      <Tr>
+        <Td>Natalie</Td>
+        <Td>Portman</Td>
+        <Td>
+          <Badge variant="green">Connected</Badge>
+        </Td>
+        <Td>Actor</Td>
+      </Tr>
+      <Tr>
+        <Td>Luke</Td>
+        <Td>Skywalker</Td>
+        <Td>
+          <Badge variant="red">Disconnected</Badge>
+        </Td>
+        <Td>Star wars</Td>
+      </Tr>
+    </Tbody>
+    <Tfoot css={{ c: '$hiContrast' }}>
+      <Tr>
+        <Td css={{ textAlign: 'center' }}>
+          <Button
+            ghost
+            variant="secondary"
+            css={{ fontSize: '$1', height: '$5', boxShadow: 'none' }}
+          >
+            Load more...
+          </Button>
+        </Td>
+      </Tr>
+    </Tfoot>
+  </TableForStory>
 );
 
 export const Columns: ComponentStory<any> = ({ transform, ...args }) => (

--- a/components/AriaTable/AriaTable.stories.tsx
+++ b/components/AriaTable/AriaTable.stories.tsx
@@ -14,6 +14,7 @@ import {
 } from './AriaTable';
 import { Badge } from '../Badge';
 import { Button } from '../Button';
+import { Flex } from '../Flex';
 import { UnstyledLink } from '../Link';
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
 
@@ -308,62 +309,153 @@ const Customize: ComponentStory<any> = (args) => (
 );
 
 export const Columns: ComponentStory<any> = ({ transform, ...args }) => (
-  <TableForStory aria-label="People" aria-describedby="basic-table-caption" {...args}>
-    <Caption id="basic-table-caption">People with some information</Caption>
-    <Thead>
-      <Tr>
-        <Th transform={transform}>first name</Th>
-        <Th transform={transform}>last name</Th>
-        <Th transform={transform}>Status</Th>
-        <Th transform={transform}>Role</Th>
-      </Tr>
-    </Thead>
-    <Tbody>
-      <Tr>
-        <Td>John</Td>
-        <Td>Doe</Td>
-        <Td>
-          <Badge variant="green">Connected</Badge>
-        </Td>
-        <Td>Developer</Td>
-      </Tr>
-      <Tr>
-        <Td>Johny</Td>
-        <Td>Depp</Td>
-        <Td>
-          <Badge variant="orange">AFK</Badge>
-        </Td>
-        <Td>Actor</Td>
-      </Tr>
-      <Tr>
-        <Td>Natalie</Td>
-        <Td>Portman</Td>
-        <Td>
-          <Badge variant="green">Connected</Badge>
-        </Td>
-        <Td>Actor</Td>
-      </Tr>
-      <Tr>
-        <Td>Luke</Td>
-        <Td>Skywalker</Td>
-        <Td>
-          <Badge variant="red">Disconnected</Badge>
-        </Td>
-        <Td>Star wars</Td>
-      </Tr>
-    </Tbody>
-    <Tfoot>
-      <Tr>
-        <Td colSpan={4} css={{ textAlign: 'center' }}>
-          <Button
-            ghost
-            variant="secondary"
-            css={{ fontSize: '$1', height: '$5', boxShadow: 'none' }}
-          >
-            Load more...
-          </Button>
-        </Td>
-      </Tr>
-    </Tfoot>
-  </TableForStory>
+  <Flex direction="column" gap="4">
+    <TableForStory aria-label="People" aria-describedby="basic-table-caption" {...args}>
+      <Caption size="10" id="basic-table-caption">
+        People with some information
+      </Caption>
+      <Thead>
+        <Tr>
+          <Th transform={transform}>first name</Th>
+          <Th transform={transform}>last name</Th>
+          <Th transform={transform}>Status</Th>
+          <Th transform={transform}>Role</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        <Tr>
+          <Td>John</Td>
+          <Td>Doe</Td>
+          <Td>
+            <Badge variant="green">Connected</Badge>
+          </Td>
+          <Td>Developer</Td>
+        </Tr>
+        <Tr>
+          <Td>Johny</Td>
+          <Td>Depp</Td>
+          <Td>
+            <Badge variant="orange">AFK</Badge>
+          </Td>
+          <Td>Actor</Td>
+        </Tr>
+        <Tr>
+          <Td>Natalie</Td>
+          <Td>Portman</Td>
+          <Td>
+            <Badge variant="green">Connected</Badge>
+          </Td>
+          <Td>Actor</Td>
+        </Tr>
+        <Tr>
+          <Td>Luke</Td>
+          <Td>Skywalker</Td>
+          <Td>
+            <Badge variant="red">Disconnected</Badge>
+          </Td>
+          <Td>Star wars</Td>
+        </Tr>
+      </Tbody>
+      <Tfoot>
+        <Tr>
+          <Td colSpan={4} css={{ textAlign: 'center' }}>
+            <Button
+              ghost
+              variant="secondary"
+              css={{ fontSize: '$1', height: '$5', boxShadow: 'none' }}
+            >
+              Load more...
+            </Button>
+          </Td>
+        </Tr>
+      </Tfoot>
+    </TableForStory>
+    <TableForStory aria-label="People" aria-describedby="basic-table-caption" {...args}>
+      <Caption size="10" id="basic-table-caption">
+        People with some information
+      </Caption>
+      <Thead>
+        <Tr>
+          <Th transform={transform}>first name</Th>
+          <Th transform={transform}>last name</Th>
+          <Th transform={transform}>Status</Th>
+          <Th transform={transform}>Role</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        <Tr>
+          <Td>John</Td>
+          <Td>Doe</Td>
+          <Td>
+            <Badge variant="green">Connected</Badge>
+          </Td>
+          <Td>Developer</Td>
+        </Tr>
+        <Tr>
+          <Td>Johny</Td>
+          <Td>Depp</Td>
+          <Td>
+            <Badge variant="orange">AFK</Badge>
+          </Td>
+          <Td>Actor</Td>
+        </Tr>
+        <Tr>
+          <Td>Natalie</Td>
+          <Td>Portman</Td>
+          <Td>
+            <Badge variant="green">Connected</Badge>
+          </Td>
+          <Td>Actor</Td>
+        </Tr>
+        <Tr>
+          <Td>Luke</Td>
+          <Td>Skywalker</Td>
+          <Td>
+            <Badge variant="red">Disconnected</Badge>
+          </Td>
+          <Td>Star wars</Td>
+        </Tr>
+      </Tbody>
+      <Tfoot>
+        <Tr>
+          <Td css={{ textAlign: 'left' }}>
+            <Button
+              ghost
+              variant="secondary"
+              css={{ fontSize: '$1', height: '$5', boxShadow: 'none' }}
+            >
+              One
+            </Button>
+          </Td>
+          <Td css={{ textAlign: 'left' }}>
+            <Button
+              ghost
+              variant="secondary"
+              css={{ fontSize: '$1', height: '$5', boxShadow: 'none' }}
+            >
+              Two
+            </Button>
+          </Td>
+          <Td css={{ textAlign: 'left' }}>
+            <Button
+              ghost
+              variant="secondary"
+              css={{ fontSize: '$1', height: '$5', boxShadow: 'none' }}
+            >
+              Three
+            </Button>
+          </Td>
+          <Td css={{ textAlign: 'left' }}>
+            <Button
+              ghost
+              variant="secondary"
+              css={{ fontSize: '$1', height: '$5', boxShadow: 'none' }}
+            >
+              Four
+            </Button>
+          </Td>
+        </Tr>
+      </Tfoot>
+    </TableForStory>
+  </Flex>
 );

--- a/components/AriaTable/AriaTable.tsx
+++ b/components/AriaTable/AriaTable.tsx
@@ -80,7 +80,15 @@ export const Td = forwardRef<
         : {},
     [colSpan]
   );
-  return <StyledTd ref={ref} role="cell" css={merge(colSpanCss, css)} {...props} />;
+  return (
+    <StyledTd
+      ref={ref}
+      aria-colspan={colSpan}
+      role="cell"
+      css={merge(colSpanCss, css)}
+      {...props}
+    />
+  );
 });
 
 const StyledThead = styled('div', TableThead, {

--- a/components/AriaTable/AriaTable.tsx
+++ b/components/AriaTable/AriaTable.tsx
@@ -60,11 +60,11 @@ export const Tr = forwardRef<ElementRef<typeof StyledTr>, TrProps>(
         if (!isValidElement(child)) {
           return false;
         }
-        const { colSpan } = child.props as TdProps;
-        return !!colSpan;
+        const { fullColSpan } = child.props as TdProps;
+        return !!fullColSpan;
       });
       if (hasColSpanChildren && arrayChildren.length > 1) {
-        throw new Error('Using colSpan is allowed only for a single full width Td.');
+        throw new Error('Using fullColSpan is allowed only for a single full width Td.');
       }
     }
 
@@ -91,34 +91,40 @@ export const Th = forwardRef<ElementRef<typeof StyledTh>, ThProps>((props, ref) 
 const StyledTd = styled('span', TableTd, {
   display: 'table-cell',
 });
+
+const FillerTd = styled(StyledTd, {
+  visibility: 'hidden',
+});
 export interface TdProps
   extends Omit<ComponentProps<typeof StyledTd>, 'css'>,
     VariantProps<typeof StyledTd>,
     VariantProps<typeof TableTd> {
   css?: CSS;
-  colSpan?: number;
+  fullColSpan?: boolean;
 }
 export const Td = forwardRef<ElementRef<typeof StyledTd>, TdProps>(
-  ({ colSpan, css, ...props }, ref) => {
-    const colSpanCss = useMemo(
+  ({ fullColSpan, css, ...props }, ref) => {
+    const fullColSpanCss = useMemo(
       () =>
-        colSpan
+        fullColSpan
           ? {
-              width: `${Math.max(colSpan || 0, 0) * 100}%`,
-              float: 'left',
+              position: 'absolute',
+              left: 0,
+              width: '100%',
+              height: '100%',
             }
           : {},
-      [colSpan]
+      [fullColSpan]
     );
-    return (
-      <StyledTd
-        ref={ref}
-        aria-colspan={colSpan}
-        role="cell"
-        css={merge(colSpanCss, css)}
-        {...props}
-      />
-    );
+    if (fullColSpan) {
+      return (
+        <>
+          <FillerTd css={css} {...props} />
+          <StyledTd ref={ref} role="cell" css={merge(fullColSpanCss, css)} {...props} />
+        </>
+      );
+    }
+    return <StyledTd ref={ref} role="cell" css={css} {...props} />;
   }
 );
 

--- a/components/AriaTable/AriaTable.tsx
+++ b/components/AriaTable/AriaTable.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps, ElementRef, forwardRef } from 'react';
+import React, { ComponentProps, ElementRef, forwardRef, useMemo } from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import { styled, VariantProps, CSS } from '../../stitches.config';
 import {
@@ -11,6 +11,7 @@ import {
   Thead as TableThead,
   Table as TableTable,
 } from '../Table';
+import merge from 'lodash.merge';
 
 export const Caption = styled('div', TableCaption, {
   display: 'table-caption',
@@ -67,8 +68,20 @@ export const Td = forwardRef<
   ElementRef<typeof StyledTd>,
   Omit<ComponentProps<typeof StyledTd>, 'css'> &
     VariantProps<typeof StyledTd> &
-    VariantProps<typeof TableTd> & { css?: CSS }
->((props, ref) => <StyledTd ref={ref} role="cell" {...props} />);
+    VariantProps<typeof TableTd> & { css?: CSS; colSpan?: number }
+>(({ colSpan, css, ...props }, ref) => {
+  const colSpanCss = useMemo(
+    () =>
+      colSpan
+        ? {
+            width: `${Math.max(colSpan || 0, 0) * 100}%`,
+            float: 'left',
+          }
+        : {},
+    [colSpan]
+  );
+  return <StyledTd ref={ref} role="cell" css={merge(colSpanCss, css)} {...props} />;
+});
 
 const StyledThead = styled('div', TableThead, {
   display: 'table-header-group',

--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -51,6 +51,7 @@ export const Th = styled('th', Label, {
 });
 
 export const Td = styled('td', {
+  boxSizing: 'border-box',
   p: '$5 $3',
   borderBottom: '1px solid $tableRowBorder',
   fontSize: '$3',


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Description

<!--
Link the issue and give some description of the implementation
For any issue on Github solved by this PR, please use the closing keywords, e.g. Closes #number or Fixes #number
-->

Add `fullColSpan`  boolean prop to `AriaTd`, so that we can span a single column inside a whole table footer. 

Previously, Footer content was not spanning fully, this behavior stayed unnoticed.

After some trials, I ended up with an absolute position hack to ensure the cell always spanned the full footer.

Implementing the `colSpan` behavior is too complex for the need, that's why I went for a hack.

### a11y

a11y-wise, the hidden cell is also hidden from the accessibility tree, as [MDN states](https://developer.mozilla.org/en-US/docs/Web/CSS/visibility#accessibility_concerns). 

For top-notch a11y, it would be nice that implementors precise `aria-colspan`, as shown in the stories.

Computing that value is really tricky on complex tables, hence I'm in favor of letting users setting this attribute themselves. 

## Preview

<!--
Here you can add a video showcasing the new feature or the before/after comparison if it's a fix
-->

### Before

![image](https://user-images.githubusercontent.com/3367393/158441766-2a437360-59bf-47a4-a7a6-5bf9e8ae3d20.png)


### After

![image](https://user-images.githubusercontent.com/3367393/158441672-b81ec842-fdb7-4f31-a014-87ed063ddae0.png)

## How to test?

<!--
If you consider the change needs specific instructions on how to test, use this section to describe it step-by-step.
-->

Check Aria table stories

## Good PR checkboxes

- [x] Change has been tested
- [ ] Added/Updated tests
- [x] Added/Updated stories
- [x] PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
- [x] Labels are set
- [x] Project is linked

## Good Review checkboxes

<details>
<summary> ℹ️  Copy the snippet and paste in the review field to fill it</summary>

```markdown
- [ ] I've tested the changes
- [ ] I've agreed on the unit tests (soon to come)
- [ ] I've checked the stories
- [ ] I've read the code and understood it
- [ ] I don't have any more questions
- [ ] I've described any optional improvements
- [ ] I checked PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
```

</details>
