### PR TITLE
chore: add project info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
     "dist"
   ],
   "types": "dist/index.d.ts",
+  "homepage": "https://traefik.github.io/faency/",
+  "repository": "https://github.com/traefik/faency",
+  "bugs": {
+    "url": "https://github.com/traefik/faency/issues"
+  },
   "scripts": {
     "prettier": "prettier --write .",
     "test": "echo \"Error: no test specified\" && exit 0",


### PR DESCRIPTION
Adds missing info related to issues and the project to the `package.json`.