### PR TITLE
fix: table default alignment

### DIFF
--- a/components/AriaTable/AriaTable.stories.tsx
+++ b/components/AriaTable/AriaTable.stories.tsx
@@ -15,8 +15,11 @@ import {
 import { Badge } from '../Badge';
 import { Button } from '../Button';
 import { Flex } from '../Flex';
+import { Box } from '../Box';
 import { UnstyledLink } from '../Link';
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
+import { Image } from '../Image';
+import { Text } from '../Text';
 
 const BaseTable = (props: TableProps): JSX.Element => <Table {...props} />;
 const TableForStory = modifyVariantsForStory<TableVariants, TableProps>(BaseTable);
@@ -523,4 +526,33 @@ export const Columns: ComponentStory<any> = ({ transform, ...args }) => (
       </Tfoot>
     </TableForStory>
   </Flex>
+);
+
+const FlexIssue = () => (
+  <Flex align="center" justify="center">
+    <Image src="https://picsum.photos/38/38" />
+  </Flex>
+);
+
+export const VerticalAlignment: ComponentStory<any> = (args) => (
+  <TableForStory>
+    <Thead>
+      <Tr>
+        <Th>Flex issue column</Th>
+        <Th>Column</Th>
+      </Tr>
+    </Thead>
+    <Tbody>
+      <Tr>
+        <Td>
+          <FlexIssue />
+        </Td>
+        <Td>
+          <Flex align="center" justify="center">
+            <Text>Cell</Text>
+          </Flex>
+        </Td>
+      </Tr>
+    </Tbody>
+  </TableForStory>
 );

--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -19,6 +19,7 @@ export const Tbody = styled('tbody', {
 export const Th = styled('th', Label, {
   // override Label
   display: 'table-cell',
+  verticalAlign: 'inherit',
 
   borderTopLeftRadius: 'inherit',
   borderTopRightRadius: 'inherit',
@@ -56,6 +57,7 @@ export const Td = styled('td', {
   borderBottom: '1px solid $tableRowBorder',
   fontSize: '$3',
   lineHeight: '16px',
+  verticalAlign: 'inherit',
   variants: {
     subtle: {
       true: {
@@ -81,6 +83,7 @@ export const Td = styled('td', {
 });
 
 export const Tr = styled('tr', {
+  verticalAlign: 'inherit',
   '&:hover': {
     color: '$tableHoverText',
   },


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Description

<!--
Link the issue and give some description of the implementation
For any issue on Github solved by this PR, please use the closing keywords, e.g. Closes #number or Fixes #number
-->

User agents on firefox and chrome enforce `verticalAlign: 'inherit'` for table rows (`tr`) and cells (`td`, `th`), and enforce `verticalAlign: 'middle'` for row groups (`thead`, `tbody`, `tfoot`).

This PR ensures this is set by default.

For `Aria` variants of the `Table`, this allows not depending on user agent and implementing the same default behavior.

- chrome
![first](https://user-images.githubusercontent.com/38889364/161782215-a1e6fa4d-d6c0-4961-a583-446396097b06.png)

- firefox
![second](https://user-images.githubusercontent.com/38889364/161782234-569c5da1-57b4-496b-be74-6cc528b56b93.png)

When cell content has different sizes, everything will therefore be centered.

## Preview

![image](https://user-images.githubusercontent.com/3367393/161748662-4cb4f311-5b91-4ae6-83f9-9209ab2b77fd.png)


## Good PR checkboxes

- [x] Change has been tested
- [ ] Added/Updated tests
- [x] Added/Updated stories
- [x] PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
- [x] Labels are set
- [x] Project is linked

## Good Review checkboxes

<details>
<summary> ℹ️  Copy the snippet and paste in the review field to fill it</summary>

```markdown
- [ ] I've tested the changes
- [ ] I've agreed on the unit tests (soon to come)
- [ ] I've checked the stories
- [ ] I've read the code and understood it
- [ ] I don't have any more questions
- [ ] I've described any optional improvements
- [ ] I checked PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
```

</details>
