### PR TITLE
fix: badge border radius on hover

### DIFF
--- a/components/Badge/Badge.tsx
+++ b/components/Badge/Badge.tsx
@@ -102,7 +102,7 @@ const StyledButtonBadge = styled('button', BADGE_BASE_STYLES, {
       right: 0,
       bottom: 0,
       left: 0,
-      borderRadius: '$pill',
+      borderRadius: 'inherit',
     },
   },
 });


### PR DESCRIPTION
## Description

- Fixes https://github.com/traefik/faency/issues/303

Fix `border-radius` on badge hover state.


## Preview
![image](https://user-images.githubusercontent.com/70909035/162716431-b64b6477-d2bf-439b-978f-df14c7ca50c2.png)


## How to test?

Check the story for badge, make sure there are no offsetting border outside of the badge itself when we hover.

## Good PR checkboxes

- [x] Change has been tested
- [ ] Added/Updated tests
- [ ] Added/Updated stories
- [x] PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
- [x] Labels are set
- [x] Project is linked

## Good Review checkboxes

<details>
<summary> ℹ️  Copy the snippet and paste in the review field to fill it</summary>

```markdown
- [ ] I've tested the changes
- [ ] I've agreed on the unit tests (soon to come)
- [ ] I've checked the stories
- [ ] I've read the code and understood it
- [ ] I don't have any more questions
- [ ] I've described any optional improvements
- [ ] I checked PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
```

</details>
