### PR TITLE
feat: Skeleton, improve inferred display

### DIFF
--- a/components/Skeleton/Skeleton.stories.tsx
+++ b/components/Skeleton/Skeleton.stories.tsx
@@ -3,12 +3,15 @@ import React from 'react';
 
 import { Skeleton, SkeletonProps, SkeletonVariants } from './Skeleton';
 import { Flex } from '../Flex';
+import { Box } from '../Box';
 import { Heading } from '../Heading';
 import { Text as FaencyText } from '../Text';
 import { Avatar } from '../Avatar';
 import { Badge as FaencyBadge } from '../Badge';
+import { Bubble } from '../Bubble';
 import { Button as FaencyButton } from '../Button';
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
+import { Cross1Icon } from '@radix-ui/react-icons';
 
 const BaseSkeleton = (props: SkeletonProps): JSX.Element => <Skeleton {...props} />;
 const SkeletonForStory = modifyVariantsForStory<SkeletonVariants, SkeletonProps>(BaseSkeleton);
@@ -117,6 +120,46 @@ export const BadgeInferred: ComponentStory<typeof SkeletonForStory> = () => (
     </Skeleton>
   </Flex>
 );
+
+export const BubbleInferred: ComponentStory<typeof SkeletonForStory> = () => (
+  <Flex gap="3" direction="column">
+    <Skeleton variant="circle">
+      <Bubble noAnimation size="x-small" />
+    </Skeleton>
+    <Skeleton variant="circle">
+      <Bubble noAnimation size="small" />
+    </Skeleton>
+    <Skeleton variant="circle">
+      <Bubble noAnimation size="medium" />
+    </Skeleton>
+    <Skeleton variant="circle">
+      <Bubble noAnimation size="large" />
+    </Skeleton>
+    <Skeleton variant="circle">
+      <Bubble noAnimation size="x-large" />
+    </Skeleton>
+  </Flex>
+);
+
+export const CustomInferred: ComponentStory<typeof SkeletonForStory> = (args) => (
+  <Flex gap="3" direction="column">
+    <Skeleton {...args}>
+      <Box css={{ width: 35, height: 20 }} />
+    </Skeleton>
+    <Skeleton {...args}>
+      <Cross1Icon />
+    </Skeleton>
+  </Flex>
+);
+CustomInferred.args = {
+  variant: 'square',
+};
+CustomInferred.argTypes = {
+  variant: {
+    options: ['square', 'circle', 'badge', 'button', 'text'],
+    control: 'inline-radio',
+  },
+};
 
 export const Customs: ComponentStory<typeof SkeletonForStory> = () => (
   <Flex direction="column" gap={3}>

--- a/components/Skeleton/Skeleton.tsx
+++ b/components/Skeleton/Skeleton.tsx
@@ -15,6 +15,7 @@ export const Skeleton = styled('div', {
   '&:not(:empty)': {
     '& > *': {
       visibility: 'hidden',
+      display: 'block',
     },
     maxWidth: 'fit-content',
   },
@@ -45,11 +46,9 @@ export const Skeleton = styled('div', {
       },
       badge: {
         borderRadius: '$pill',
-        display: 'inline-flex',
       },
       button: {
         borderRadius: '$3',
-        display: 'inline-flex',
       },
       text: {
         '&:empty:before': {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Description

<!--
Link the issue and give some description of the implementation
For any issue on Github solved by this PR, please use the closing keywords, e.g. Closes #number or Fixes #number
-->

Previously, the layout of a `Bubble` was not properly inferred by the Skeleton, because it did not handle inline layout properly.

Improves inferred display of `Skeleton` by enforcing children to `display: 'block'`, instead of enforcing the `Skeleton` to `display:'inline-flex` for possibly inline children.

Added BubbleInferred and CustomInferred stories.

## Preview

<!--
Here you can add a video showcasing the new feature or the before/after comparison if it's a fix
-->

Bubble inferred layout previously was what happens when I disable the display styling.

https://user-images.githubusercontent.com/3367393/162942042-b9b3b5e4-ae2b-4305-921b-7393b521384d.mp4


## Good PR checkboxes

- [x] Change has been tested
- [ ] Added/Updated tests
- [x] Added/Updated stories
- [x] PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
- [x] Labels are set
- [x] Project is linked

## Good Review checkboxes

<details>
<summary> ℹ️  Copy the snippet and paste in the review field to fill it</summary>

```markdown
- [ ] I've tested the changes
- [ ] I've agreed on the unit tests (soon to come)
- [ ] I've checked the stories
- [ ] I've read the code and understood it
- [ ] I don't have any more questions
- [ ] I've described any optional improvements
- [ ] I checked PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
```

</details>
