### PR TITLE
feat: badge `asChild`

### DIFF
--- a/components/Badge/Badge.stories.tsx
+++ b/components/Badge/Badge.stories.tsx
@@ -4,6 +4,7 @@ import { VariantProps } from '../../stitches.config';
 import { Badge, COLORS } from './Badge';
 import { Flex } from '../Flex';
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
+import { UnstyledLink } from '../Link';
 
 type BadgeVariants = VariantProps<typeof Badge>;
 type BadgeProps = BadgeVariants & {};
@@ -83,5 +84,11 @@ Interactive.args = {
 const Customize: ComponentStory<typeof BadgeForStory> = (args) => (
   <Badge css={{ c: '$hiContrast' }} {...args}>
     Customize
+  </Badge>
+);
+
+export const BadgeLink: ComponentStory<typeof BadgeForStory> = (args) => (
+  <Badge asChild interactive {...args}>
+    <UnstyledLink href="https://traefik.io">Link</UnstyledLink>
   </Badge>
 );

--- a/components/Badge/Badge.test.tsx
+++ b/components/Badge/Badge.test.tsx
@@ -1,0 +1,15 @@
+import { Badge } from './Badge';
+import { UnstyledLink } from '../Link';
+import { render } from '@testing-library/react';
+
+describe('Badge', () => {
+  it('should render Badge as link', () => {
+    const { getByRole } = render(
+      <Badge asChild interactive>
+        <UnstyledLink href="https://traefik.io">Link</UnstyledLink>
+      </Badge>
+    );
+
+    expect(getByRole('link')).toBeInTheDocument();
+  });
+});

--- a/components/Badge/Badge.tsx
+++ b/components/Badge/Badge.tsx
@@ -1,5 +1,6 @@
-import React, { ComponentProps, createContext } from 'react';
-import { styled, VariantProps, CSS } from '../../stitches.config';
+import React, { ComponentProps, useMemo } from 'react';
+import { styled, VariantProps } from '../../stitches.config';
+import { Slot } from '@radix-ui/react-slot';
 
 export const COLORS = ['gray', 'red', 'blue', 'green', 'neon', 'orange', 'purple'] as const;
 type COLOR_VALUES = typeof COLORS[number];
@@ -85,7 +86,8 @@ const BADGE_BASE_STYLES = {
   },
 };
 
-export const StyledSpanBadge = styled('span', BADGE_BASE_STYLES);
+const StyledSpanBadge = styled('span', BADGE_BASE_STYLES);
+const StyledSpanBadgeSlot = styled(Slot, StyledSpanBadge);
 
 const StyledButtonBadge = styled('button', BADGE_BASE_STYLES, {
   '&:focus-visible': {
@@ -106,17 +108,23 @@ const StyledButtonBadge = styled('button', BADGE_BASE_STYLES, {
     },
   },
 });
+const StyledButtonBadgeSlot = styled(Slot, StyledButtonBadge);
 
 interface BadgeProps
   extends ComponentProps<typeof StyledButtonBadge>,
-    VariantProps<typeof StyledButtonBadge> {}
+    VariantProps<typeof StyledButtonBadge> {
+  asChild?: boolean;
+}
 
 export const Badge = React.forwardRef<React.ElementRef<typeof StyledButtonBadge>, BadgeProps>(
-  ({ interactive, ...props }, forwardedRef) => {
-    return interactive ? (
-      <StyledButtonBadge {...props} ref={forwardedRef} />
-    ) : (
-      <StyledSpanBadge {...props} ref={forwardedRef} />
-    );
+  ({ interactive, asChild, ...props }, forwardedRef) => {
+    const Component = useMemo(() => {
+      if (interactive) {
+        return asChild ? StyledButtonBadgeSlot : StyledButtonBadge;
+      }
+      return asChild ? StyledSpanBadgeSlot : StyledSpanBadge;
+    }, [asChild]);
+
+    return <Component {...props} ref={forwardedRef} />;
   }
 );


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Description

<!--
Link the issue and give some description of the implementation
For any issue on Github solved by this PR, please use the closing keywords, e.g. Closes #number or Fixes #number
-->

- Closes #351 

I chose to implement `asChild` behavior instead of `as` prop, which is really difficult to handle when we implement components on top of `styled`.

Also this choice follows the following RFC:
- https://github.com/traefik/faency/issues/218

usgae of `as` prop is not disabled by this PR, simply, we cannot handle polymorphic typing properly. Users can still remove types from the component and make use of `as` prop if they prefer.

Added test and story to back the use case of a "BadgeLink"

## Preview

<!--
Here you can add a video showcasing the new feature or the before/after comparison if it's a fix
-->

![image](https://user-images.githubusercontent.com/3367393/163131607-05065c4a-00aa-42b6-bdc7-89df7d39aa21.png)


## Breaking changes

<!--
Please mention any breaking changes. It's important to have a complete description of the change for reviewers to validate.
Once your PR is merged, an automatic release will be issued. Please add this section to its content.
-->

I consider this change non-breaking, because as the issue states, there was an unexpected breaking change brought by https://github.com/traefik/faency/commit/b2851f5c542488e2176185505210db9c75699e5d, which removed `as` prop and  stitches' polymorphic typings. Do you think we should consider this PR bringing a breaking change?

## How to test?

<!--
If you consider the change needs specific instructions on how to test, use this section to describe it step-by-step.
-->

- Check story and test
- Review code
- Share your opinion on whether this PR should be considered breaking change or not

## Good PR checkboxes

- [x] Change has been tested
- [x] Added/Updated tests
- [x] Added/Updated stories
- [x] PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
- [x] Labels are set
- [x] Project is linked

## Good Review checkboxes

<details>
<summary> ℹ️  Copy the snippet and paste in the review field to fill it</summary>

```markdown
- [ ] I've tested the changes
- [ ] I've agreed on the unit tests (soon to come)
- [ ] I've checked the stories
- [ ] I've read the code and understood it
- [ ] I don't have any more questions
- [ ] I've described any optional improvements
- [ ] I checked PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
```

</details>
