### PR TITLE
feat: button `asChild`

### DIFF
--- a/components/Button/Button.stories.tsx
+++ b/components/Button/Button.stories.tsx
@@ -5,6 +5,7 @@ import { ButtonForStory } from './Button';
 import { Flex } from '../Flex';
 import { Text } from '../Text';
 import { InfoCircledIcon } from '@radix-ui/react-icons';
+import { UnstyledLink } from '../Link';
 
 export default {
   title: 'Components/Button',
@@ -88,5 +89,19 @@ Waiting.args = {
 };
 
 const Customize: ComponentStory<typeof ButtonForStory> = (args) => (
-  <ButtonForStory css={{ c: '$hiContrast' }} {...args}>Button</ButtonForStory>
+  <ButtonForStory css={{ c: '$hiContrast' }} {...args}>
+    Button
+  </ButtonForStory>
 );
+
+export const ButtonLink: ComponentStory<typeof ButtonForStory> = (args) => (
+  <ButtonForStory asChild {...args}>
+    <UnstyledLink href="https://traefik.io">Button</UnstyledLink>
+  </ButtonForStory>
+);
+ButtonLink.argTypes = {
+  state: {
+    options: ['waiting', undefined],
+    control: 'inline-radio',
+  },
+};

--- a/components/Button/Button.test.tsx
+++ b/components/Button/Button.test.tsx
@@ -1,0 +1,15 @@
+import { Button } from './Button';
+import { UnstyledLink } from '../Link';
+import { render } from '@testing-library/react';
+
+describe('Button', () => {
+  it('should render Button as link', () => {
+    const { getByRole } = render(
+      <Button asChild>
+        <UnstyledLink href="https://traefik.io">Link</UnstyledLink>
+      </Button>
+    );
+
+    expect(getByRole('link')).toBeInTheDocument();
+  });
+});

--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { ComponentProps } from 'react';
 import { styled, keyframes, CSS, VariantProps } from '../../stitches.config';
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
+import { Slot } from '@radix-ui/react-slot';
 
 export const BUTTON_BASE_STYLES = {
   appearance: 'none',
@@ -238,10 +239,9 @@ export const StyledButton = styled('button', BUTTON_BASE_STYLES, {
     variant: 'primary',
   },
 });
+const StyledButtonSlot = styled(Slot, StyledButton);
 
-type ButtonVariants = VariantProps<typeof StyledButton>;
-
-const Waiting = styled('div', {
+export const Waiting = styled('div', {
   position: 'absolute',
   top: 0,
   left: '-100%',
@@ -284,10 +284,21 @@ const Waiting = styled('div', {
   },
 });
 
-type ButtonProps = React.ButtonHTMLAttributes<any> & ButtonVariants & { css?: CSS };
+export interface ButtonVariants extends VariantProps<typeof StyledButton> {}
+export interface ButtonProps extends ComponentProps<typeof StyledButton>, ButtonVariants {
+  css?: CSS;
+  asChild?: boolean;
+}
 
 export const Button = React.forwardRef<React.ElementRef<typeof StyledButton>, ButtonProps>(
-  ({ children, ...props }, forwardedRef) => {
+  ({ children, asChild, ...props }, forwardedRef) => {
+    if (asChild) {
+      return (
+        <StyledButtonSlot ref={forwardedRef} {...props}>
+          {children}
+        </StyledButtonSlot>
+      );
+    }
     return (
       <StyledButton {...props} ref={forwardedRef}>
         <>

--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -21,7 +21,7 @@ const BG_SIZES = {
   large: '$sizes$10',
 };
 
-const backgroundSizeAnimation = (size) => ({
+const backgroundSizeAnimation = (size: keyof typeof BG_SIZES) => ({
   $$bgSize: BG_SIZES[size],
   backgroundSize: '$$bgSize',
   backgroundImage: `linear-gradient(

--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps } from 'react';
+import React, { ComponentProps, useMemo } from 'react';
 import { styled, keyframes, CSS, VariantProps } from '../../stitches.config';
 import { modifyVariantsForStory } from '../../utils/modifyVariantsForStory';
 import { Slot } from '@radix-ui/react-slot';
@@ -15,6 +15,27 @@ export const BUTTON_BASE_STYLES = {
   },
 };
 
+const BG_SIZES = {
+  small: '$sizes$8',
+  medium: '$sizes$9',
+  large: '$sizes$10',
+};
+
+const backgroundSizeAnimation = (size) => ({
+  $$bgSize: BG_SIZES[size],
+  backgroundSize: '$$bgSize',
+  backgroundImage: `linear-gradient(
+            -45deg,
+            transparent 33%,
+            $colors$deepBlue4 33%,
+            $colors$deepBlue4 66%,
+            transparent 66%
+          )`,
+  animation: `${keyframes({
+    '100%': { transform: 'translateX($$bgSize)' },
+  })} 500ms linear infinite`,
+});
+
 export const StyledButton = styled('button', BUTTON_BASE_STYLES, {
   // Reset
   all: 'unset',
@@ -25,19 +46,13 @@ export const StyledButton = styled('button', BUTTON_BASE_STYLES, {
     boxSizing: 'border-box',
     content: '""',
     position: 'absolute',
-    top: 0,
-    right: 0,
-    bottom: 0,
-    left: 0,
+    inset: 0,
   },
   '&::after': {
     boxSizing: 'border-box',
     content: '""',
     position: 'absolute',
-    top: 0,
-    right: 0,
-    bottom: 0,
-    left: 0,
+    inset: 0,
   },
 
   // Custom reset?
@@ -162,6 +177,11 @@ export const StyledButton = styled('button', BUTTON_BASE_STYLES, {
         c: 'transparent',
         overflow: 'hidden',
         pointerEvents: 'none',
+        '&::after': {
+          left: '-100%',
+          width: '200%',
+          ...backgroundSizeAnimation('medium'),
+        },
       },
     },
     ghost: {
@@ -233,6 +253,20 @@ export const StyledButton = styled('button', BUTTON_BASE_STYLES, {
         },
       },
     },
+    {
+      size: 'small',
+      state: 'waiting',
+      css: {
+        '&::after': backgroundSizeAnimation('small'),
+      },
+    },
+    {
+      size: 'large',
+      state: 'waiting',
+      css: {
+        '&::after': backgroundSizeAnimation('large'),
+      },
+    },
   ],
   defaultVariants: {
     size: 'medium',
@@ -240,49 +274,6 @@ export const StyledButton = styled('button', BUTTON_BASE_STYLES, {
   },
 });
 const StyledButtonSlot = styled(Slot, StyledButton);
-
-export const Waiting = styled('div', {
-  position: 'absolute',
-  top: 0,
-  left: '-100%',
-  width: '200%',
-  height: '100%',
-  backgroundImage: `linear-gradient(
-                -45deg,
-                transparent 33%,
-                $colors$deepBlue4 33%,
-                $colors$deepBlue4 66%,
-                transparent 66%
-              )`,
-  variants: {
-    size: {
-      small: {
-        $$bgSize: '$sizes$8',
-        backgroundSize: '$$bgSize',
-        animation: `${keyframes({
-          '100%': { transform: 'translateX($sizes$8)' },
-        })} 500ms linear infinite`,
-      },
-      medium: {
-        $$bgSize: '$sizes$9',
-        backgroundSize: '$$bgSize',
-        animation: `${keyframes({
-          '100%': { transform: 'translateX($sizes$9)' },
-        })} 500ms linear infinite`,
-      },
-      large: {
-        $$bgSize: '$sizes$10',
-        backgroundSize: '$$bgSize',
-        animation: `${keyframes({
-          '100%': { transform: 'translateX($sizes$10)' },
-        })} 500ms linear infinite`,
-      },
-    },
-  },
-  defaultVariants: {
-    size: 'medium',
-  },
-});
 
 export interface ButtonVariants extends VariantProps<typeof StyledButton> {}
 export interface ButtonProps extends ComponentProps<typeof StyledButton>, ButtonVariants {
@@ -292,20 +283,11 @@ export interface ButtonProps extends ComponentProps<typeof StyledButton>, Button
 
 export const Button = React.forwardRef<React.ElementRef<typeof StyledButton>, ButtonProps>(
   ({ children, asChild, ...props }, forwardedRef) => {
-    if (asChild) {
-      return (
-        <StyledButtonSlot ref={forwardedRef} {...props}>
-          {children}
-        </StyledButtonSlot>
-      );
-    }
+    const Component = useMemo(() => (asChild ? StyledButtonSlot : StyledButton), [asChild]);
     return (
-      <StyledButton {...props} ref={forwardedRef}>
-        <>
-          {children}
-          {props.state === 'waiting' && <Waiting size={props.size} />}
-        </>
-      </StyledButton>
+      <Component ref={forwardedRef} {...props}>
+        {children}
+      </Component>
     );
   }
 );


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Description

<!--
Link the issue and give some description of the implementation
For any issue on Github solved by this PR, please use the closing keywords, e.g. Closes #number or Fixes #number
-->

- Closes #107 


I chose to implement `asChild` behavior instead of `as` prop, which is really difficult to handle when we implement components on top of `styled`.

Also this choice follows the following RFC:
- https://github.com/traefik/faency/issues/218

usgae of `as` prop is not disabled by this PR, simply, we cannot handle polymorphic typing properly. Users can still remove types from the component and make use of `as` prop if they prefer.

Added test and story to back the use case of a "ButtonLink"

I also reworked `state="waiting"` implementation, so it doesn't clash with `asChild` behavior.

## Preview

<!--
Here you can add a video showcasing the new feature or the before/after comparison if it's a fix
-->

https://user-images.githubusercontent.com/3367393/163158384-7af0ccbd-cb24-4650-a15e-dbe4313fb65f.mp4


## Good PR checkboxes

- [x] Change has been tested
- [x] Added/Updated tests
- [x] Added/Updated stories
- [x] PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
- [x] Labels are set
- [x] Project is linked

## Good Review checkboxes

<details>
<summary> ℹ️  Copy the snippet and paste in the review field to fill it</summary>

```markdown
- [ ] I've tested the changes
- [ ] I've agreed on the unit tests (soon to come)
- [ ] I've checked the stories
- [ ] I've read the code and understood it
- [ ] I don't have any more questions
- [ ] I've described any optional improvements
- [ ] I checked PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
```

</details>
