### PR TITLE
feat: collapsible table row

### DIFF
--- a/components/AriaTable/AriaTable.stories.tsx
+++ b/components/AriaTable/AriaTable.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   Table,
   TableProps,
@@ -166,52 +166,63 @@ Alignment.args = {
   align: 'start',
 };
 
-export const Interactive: ComponentStory<any> = (args) => (
-  <TableForStory>
-    <Thead>
-      <Tr>
-        <Th>Firstname</Th>
-        <Th>Lastname</Th>
-        <Th>Status</Th>
-        <Th>Role</Th>
-      </Tr>
-    </Thead>
-    <Tbody>
-      <Tr {...args}>
-        <Td>John</Td>
-        <Td>Doe</Td>
-        <Td>
-          <Badge variant="green">Connected</Badge>
-        </Td>
-        <Td>Developer</Td>
-      </Tr>
-      <Tr {...args}>
-        <Td>Johny</Td>
-        <Td>Depp</Td>
-        <Td>
-          <Badge variant="orange">AFK</Badge>
-        </Td>
-        <Td>Actor</Td>
-      </Tr>
-      <Tr {...args} active>
-        <Td>Natalie</Td>
-        <Td>Portman</Td>
-        <Td>
-          <Badge variant="green">Connected</Badge>
-        </Td>
-        <Td>Actor</Td>
-      </Tr>
-      <Tr {...args}>
-        <Td>Luke</Td>
-        <Td>Skywalker</Td>
-        <Td>
-          <Badge variant="red">Disconnected</Badge>
-        </Td>
-        <Td>Star Wars</Td>
-      </Tr>
-    </Tbody>
-  </TableForStory>
-);
+export const Interactive: ComponentStory<any> = (args) => {
+  const [selectedRow, setSelectedRow] = useState(3);
+  const makeSelectableRowProps = useCallback(
+    (rowNum: number) => ({
+      active: selectedRow === rowNum,
+      onClick: () => setSelectedRow(rowNum),
+    }),
+    [selectedRow, setSelectedRow]
+  );
+
+  return (
+    <TableForStory>
+      <Thead>
+        <Tr>
+          <Th>Firstname</Th>
+          <Th>Lastname</Th>
+          <Th>Status</Th>
+          <Th>Role</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        <Tr {...args} {...makeSelectableRowProps(1)}>
+          <Td>John</Td>
+          <Td>Doe</Td>
+          <Td>
+            <Badge variant="green">Connected</Badge>
+          </Td>
+          <Td>Developer</Td>
+        </Tr>
+        <Tr {...args} {...makeSelectableRowProps(2)}>
+          <Td>Johny</Td>
+          <Td>Depp</Td>
+          <Td>
+            <Badge variant="orange">AFK</Badge>
+          </Td>
+          <Td>Actor</Td>
+        </Tr>
+        <Tr {...args} {...makeSelectableRowProps(3)}>
+          <Td>Natalie</Td>
+          <Td>Portman</Td>
+          <Td>
+            <Badge variant="green">Connected</Badge>
+          </Td>
+          <Td>Actor</Td>
+        </Tr>
+        <Tr {...args} {...makeSelectableRowProps(4)}>
+          <Td>Luke</Td>
+          <Td>Skywalker</Td>
+          <Td>
+            <Badge variant="red">Disconnected</Badge>
+          </Td>
+          <Td>Star Wars</Td>
+        </Tr>
+      </Tbody>
+    </TableForStory>
+  );
+};
 
 Interactive.args = {
   interactive: true,
@@ -557,74 +568,87 @@ export const VerticalAlignment: ComponentStory<any> = (args) => (
   </TableForStory>
 );
 
-export const CollapsibleRow: ComponentStory<any> = (args) => (
-  <TableForStory>
-    <Thead>
-      <Tr emptyFirstColumn tableHead>
-        <Th>Firstname</Th>
-        <Th>Lastname</Th>
-        <Th>Status</Th>
-        <Th>Role</Th>
-      </Tr>
-    </Thead>
-    <Tbody>
-      <Tr
-        collapsedContent={
-          <>
-            <Tr>
-              <Td>Extra info</Td>
-              <Td>Hello</Td>
-              <Td />
-              <Td />
-            </Tr>
-            <Tr>
-              <Td>Additional</Td>
-              <Td>Information</Td>
-              <Td>And more</Td>
-              <Td />
-            </Tr>
-          </>
-        }
-        {...args}
-      >
-        <Td>John</Td>
-        <Td>Doe</Td>
-        <Td>
-          <Badge variant="green">Connected</Badge>
-        </Td>
-        <Td>Developer</Td>
-      </Tr>
-      <Tr
-        collapsedContent={
-          <>
-            <Tr>
-              <Td>Only</Td>
-              <Td>One</Td>
-              <Td>Line</Td>
-              <Td />
-            </Tr>
-          </>
-        }
-        {...args}
-      >
-        <Td>Johny</Td>
-        <Td>Depp</Td>
-        <Td>
-          <Badge variant="orange">AFK</Badge>
-        </Td>
-        <Td>Actor</Td>
-      </Tr>
-      <Tr {...args} active emptyFirstColumn>
-        <Td>Natalie</Td>
-        <Td>Portman</Td>
-        <Td>
-          <Badge variant="green">Connected</Badge>
-        </Td>
-        <Td>Actor</Td>
-      </Tr>
-    </Tbody>
-  </TableForStory>
-);
+export const CollapsibleRow: ComponentStory<any> = (args) => {
+  const [selectedRow, setSelectedRow] = useState(3);
+  const makeSelectableRowProps = useCallback(
+    (rowNum: number) => ({
+      active: selectedRow === rowNum,
+      onClick: () => setSelectedRow(rowNum),
+    }),
+    [selectedRow, setSelectedRow]
+  );
+
+  return (
+    <TableForStory>
+      <Thead>
+        <Tr emptyFirstColumn tableHead>
+          <Th>Firstname</Th>
+          <Th>Lastname</Th>
+          <Th>Status</Th>
+          <Th>Role</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        <Tr
+          collapsedContent={
+            <>
+              <Tr>
+                <Td>Extra info</Td>
+                <Td>Hello</Td>
+                <Td />
+                <Td />
+              </Tr>
+              <Tr>
+                <Td>Additional</Td>
+                <Td>Information</Td>
+                <Td>And more</Td>
+                <Td />
+              </Tr>
+            </>
+          }
+          {...makeSelectableRowProps(1)}
+          {...args}
+        >
+          <Td>John</Td>
+          <Td>Doe</Td>
+          <Td>
+            <Badge variant="green">Connected</Badge>
+          </Td>
+          <Td>Developer</Td>
+        </Tr>
+        <Tr
+          collapsedContent={
+            <>
+              <Tr>
+                <Td>Only</Td>
+                <Td>One</Td>
+                <Td>Line</Td>
+                <Td />
+              </Tr>
+            </>
+          }
+          {...makeSelectableRowProps(2)}
+          {...args}
+        >
+          <Td>Johny</Td>
+          <Td>Depp</Td>
+          <Td>
+            <Badge variant="orange">AFK</Badge>
+          </Td>
+          <Td>Actor</Td>
+        </Tr>
+        <Tr {...args} {...makeSelectableRowProps(3)} emptyFirstColumn>
+          <Td>Natalie</Td>
+          <Td>Portman</Td>
+          <Td>
+            <Badge variant="green">Connected</Badge>
+          </Td>
+          <Td>Actor</Td>
+        </Tr>
+      </Tbody>
+    </TableForStory>
+  );
+};
 
 CollapsibleRow.args = {
   interactive: true,

--- a/components/AriaTable/AriaTable.stories.tsx
+++ b/components/AriaTable/AriaTable.stories.tsx
@@ -556,3 +556,76 @@ export const VerticalAlignment: ComponentStory<any> = (args) => (
     </Tbody>
   </TableForStory>
 );
+
+export const CollapsibleRow: ComponentStory<any> = (args) => (
+  <TableForStory>
+    <Thead>
+      <Tr emptyFirstColumn tableHead>
+        <Th>Firstname</Th>
+        <Th>Lastname</Th>
+        <Th>Status</Th>
+        <Th>Role</Th>
+      </Tr>
+    </Thead>
+    <Tbody>
+      <Tr
+        collapsedContent={
+          <>
+            <Tr>
+              <Td>Extra info</Td>
+              <Td>Hello</Td>
+              <Td />
+              <Td />
+            </Tr>
+            <Tr>
+              <Td>Additional</Td>
+              <Td>Information</Td>
+              <Td>And more</Td>
+              <Td />
+            </Tr>
+          </>
+        }
+        {...args}
+      >
+        <Td>John</Td>
+        <Td>Doe</Td>
+        <Td>
+          <Badge variant="green">Connected</Badge>
+        </Td>
+        <Td>Developer</Td>
+      </Tr>
+      <Tr
+        collapsedContent={
+          <>
+            <Tr>
+              <Td>Only</Td>
+              <Td>One</Td>
+              <Td>Line</Td>
+              <Td />
+            </Tr>
+          </>
+        }
+        {...args}
+      >
+        <Td>Johny</Td>
+        <Td>Depp</Td>
+        <Td>
+          <Badge variant="orange">AFK</Badge>
+        </Td>
+        <Td>Actor</Td>
+      </Tr>
+      <Tr {...args} active emptyFirstColumn>
+        <Td>Natalie</Td>
+        <Td>Portman</Td>
+        <Td>
+          <Badge variant="green">Connected</Badge>
+        </Td>
+        <Td>Actor</Td>
+      </Tr>
+    </Tbody>
+  </TableForStory>
+);
+
+CollapsibleRow.args = {
+  interactive: true,
+};

--- a/components/AriaTable/AriaTable.tsx
+++ b/components/AriaTable/AriaTable.tsx
@@ -1,5 +1,4 @@
 import React, {
-  cloneElement,
   ComponentProps,
   ElementRef,
   forwardRef,
@@ -19,6 +18,7 @@ import {
   Td as TableTd,
   Thead as TableThead,
   Table as TableTable,
+  RenderedCollapsedContent,
 } from '../Table';
 import merge from 'lodash.merge';
 import { Box } from '../Box';
@@ -49,49 +49,6 @@ const StyledTr = styled('div', TableTr, {
 });
 const StyledTrSlot = styled(Slot, StyledTr);
 
-const RenderedCollapsedContent = ({ isOpen, UsedComponent, children }) => {
-  return Children.map(children.props.children, (child) => {
-    return (
-      <AnimatedTr isOpen={isOpen} UsedComponent={UsedComponent}>
-        {child}
-      </AnimatedTr>
-    );
-  });
-};
-
-const AnimatedTr = ({ isOpen, UsedComponent, children }) => {
-  const appliedStyle = useMemo(
-    () =>
-      isOpen
-        ? { transition: 'padding 0.2s ease-out' }
-        : {
-            transition: 'padding 0.2s ease-out',
-            lineHeight: 0,
-            fontSize: 0,
-            padding: '0px 16px',
-            border: 'none',
-          },
-    [isOpen]
-  );
-
-  const renderedChildren = useMemo(() => {
-    return Children.map(children.props.children, (child) =>
-      cloneElement(child, {
-        style: {
-          ...child.props.style,
-          ...appliedStyle,
-        },
-      })
-    );
-  }, [children, isOpen]);
-
-  return (
-    <UsedComponent>
-      <Td css={appliedStyle} />
-      {renderedChildren}
-    </UsedComponent>
-  );
-};
 export interface TrProps
   extends Omit<ComponentProps<typeof StyledTr>, 'css'>,
     VariantProps<typeof StyledTr> {
@@ -146,7 +103,7 @@ export const Tr = forwardRef<ElementRef<typeof StyledTr>, TrProps>(
           {children}
         </Component>
         {!!collapsedContent && (
-          <RenderedCollapsedContent isOpen={isCollapsed} UsedComponent={Component}>
+          <RenderedCollapsedContent isOpen={isCollapsed} TrComponent={Component} TdComponent={Td}>
             {collapsedContent}
           </RenderedCollapsedContent>
         )}

--- a/components/AriaTable/AriaTable.tsx
+++ b/components/AriaTable/AriaTable.tsx
@@ -64,7 +64,13 @@ const AnimatedTr = ({ isOpen, UsedComponent, children }) => {
     () =>
       isOpen
         ? { transition: 'padding 0.2s ease-out' }
-        : { transition: 'padding 0.2s ease-out', lineHeight: 0, fontSize: 0, padding: '0px 16px' },
+        : {
+            transition: 'padding 0.2s ease-out',
+            lineHeight: 0,
+            fontSize: 0,
+            padding: '0px 16px',
+            border: 'none',
+          },
     [isOpen]
   );
 

--- a/components/Table/Table.stories.tsx
+++ b/components/Table/Table.stories.tsx
@@ -709,11 +709,17 @@ export const CollapsibleRow: ComponentStory<any> = ({ interactive, ...args }) =>
           <Tr
             interactive={interactive}
             collapsedContent={
-              <Tr>
-                <Td />
-                <Td>Extra info</Td>
-                <Td colSpan={3}>Hello</Td>
-              </Tr>
+              <>
+                <Tr>
+                  <Td>Extra info</Td>
+                  <Td colSpan={3}>Hello</Td>
+                </Tr>
+                <Tr>
+                  <Td>Additional</Td>
+                  <Td>Information</Td>
+                  <Td colSpan={2}>And more</Td>
+                </Tr>
+              </>
             }
             {...makeSelectableRowProps(1)}
           >
@@ -724,14 +730,34 @@ export const CollapsibleRow: ComponentStory<any> = ({ interactive, ...args }) =>
             </Td>
             <Td subtle>Developer</Td>
           </Tr>
-          <Tr interactive={interactive} {...makeSelectableRowProps(2)}>
-            <Td />
+          <Tr
+            interactive={interactive}
+            collapsedContent={
+              <>
+                <Tr>
+                  <Td>Only</Td>
+                  <Td>One</Td>
+                  <Td colSpan={2}>Line</Td>
+                </Tr>
+              </>
+            }
+            {...makeSelectableRowProps(2)}
+          >
             <Td>Johnny</Td>
             <Td>Depp</Td>
             <Td subtle>
               <Badge variant="orange">AFK</Badge>
             </Td>
             <Td subtle>Actor</Td>
+          </Tr>
+          <Tr interactive={interactive} {...makeSelectableRowProps(3)}>
+            <Td />
+            <Td>Natalie</Td>
+            <Td>Portman</Td>
+            <Td>
+              <Badge variant="green">Connected</Badge>
+            </Td>
+            <Td>Actor</Td>
           </Tr>
         </Tbody>
         <Tfoot>

--- a/components/Table/Table.stories.tsx
+++ b/components/Table/Table.stories.tsx
@@ -682,3 +682,77 @@ const Customize: ComponentStory<any> = (args) => (
     </Tfoot>
   </TableForStory>
 );
+
+export const CollapsibleRow: ComponentStory<any> = ({ interactive, ...args }) => {
+  const [selectedRow, setSelectedRow] = useState(3);
+  const makeSelectableRowProps = useCallback(
+    (rowNum: number) => ({
+      active: selectedRow === rowNum,
+      onClick: () => setSelectedRow(rowNum),
+    }),
+    [selectedRow, setSelectedRow]
+  );
+
+  return (
+    <Flex direction="column" gap="4">
+      <TableForStory {...args}>
+        <Thead>
+          <Tr>
+            <Th css={{ width: 18 }} />
+            <Th>First name</Th>
+            <Th>Last name</Th>
+            <Th>Status</Th>
+            <Th>Role</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          <Tr
+            interactive={interactive}
+            collapsedContent={
+              <Tr>
+                <Td />
+                <Td>Extra info</Td>
+                <Td colSpan={3}>Hello</Td>
+              </Tr>
+            }
+            {...makeSelectableRowProps(1)}
+          >
+            <Td>John</Td>
+            <Td>Doe</Td>
+            <Td>
+              <Badge variant="green">Connected</Badge>
+            </Td>
+            <Td subtle>Developer</Td>
+          </Tr>
+          <Tr interactive={interactive} {...makeSelectableRowProps(2)}>
+            <Td />
+            <Td>Johnny</Td>
+            <Td>Depp</Td>
+            <Td subtle>
+              <Badge variant="orange">AFK</Badge>
+            </Td>
+            <Td subtle>Actor</Td>
+          </Tr>
+        </Tbody>
+        <Tfoot>
+          <Tr>
+            <Td colSpan={5} css={{ textAlign: 'center' }}>
+              <Button
+                ghost
+                variant="secondary"
+                css={{ fontSize: '$1', height: '$5', boxShadow: 'none' }}
+              >
+                Load more...
+              </Button>
+            </Td>
+          </Tr>
+        </Tfoot>
+      </TableForStory>
+    </Flex>
+  );
+};
+
+CollapsibleRow.args = {
+  interactive: true,
+  elevation: '1',
+};

--- a/components/Table/Table.stories.tsx
+++ b/components/Table/Table.stories.tsx
@@ -697,8 +697,7 @@ export const CollapsibleRow: ComponentStory<any> = ({ interactive, ...args }) =>
     <Flex direction="column" gap="4">
       <TableForStory {...args}>
         <Thead>
-          <Tr>
-            <Th css={{ width: 18 }} />
+          <Tr emptyFirstColumn tableHead>
             <Th>First name</Th>
             <Th>Last name</Th>
             <Th>Status</Th>
@@ -750,8 +749,7 @@ export const CollapsibleRow: ComponentStory<any> = ({ interactive, ...args }) =>
             </Td>
             <Td subtle>Actor</Td>
           </Tr>
-          <Tr interactive={interactive} {...makeSelectableRowProps(3)}>
-            <Td />
+          <Tr emptyFirstColumn interactive={interactive} {...makeSelectableRowProps(3)}>
             <Td>Natalie</Td>
             <Td>Portman</Td>
             <Td>

--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -144,7 +144,13 @@ const AnimatedTr = ({ isOpen, children }) => {
     () =>
       isOpen
         ? { transition: 'padding 0.2s ease-out' }
-        : { transition: 'padding 0.2s ease-out', lineHeight: 0, fontSize: 0, padding: '0px 16px' },
+        : {
+            transition: 'padding 0.2s ease-out',
+            lineHeight: 0,
+            fontSize: 0,
+            padding: '0px 16px',
+            border: 'none',
+          },
     [isOpen]
   );
 

--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -1,6 +1,14 @@
 import { ChevronDownIcon, ChevronRightIcon } from '@radix-ui/react-icons';
 import { CSS, keyframes } from '@stitches/react';
-import { Children, cloneElement, useState, useMemo } from 'react';
+import {
+  Children,
+  cloneElement,
+  useState,
+  useMemo,
+  forwardRef,
+  ElementRef,
+  ComponentProps,
+} from 'react';
 import { styled, VariantProps } from '../../stitches.config';
 import { elevationVariants } from '../Elevation';
 import { Label } from '../Label';
@@ -86,7 +94,7 @@ export const Td = styled('td', {
   },
 });
 
-const StyledTr = styled('tr', {
+export const StyledTr = styled('tr', {
   verticalAlign: 'inherit',
   '&:hover': {
     color: '$tableHoverText',
@@ -158,53 +166,51 @@ const AnimatedTr = ({ isOpen, children }) => {
     </Tr>
   );
 };
-
-export const Tr = ({
-  children,
-  collapsedContent,
-  emptyFirstColumn = false,
-  tableHead = false,
-  ...props
-}: VariantProps<typeof StyledTr> & {
+export interface TrProps extends ComponentProps<typeof StyledTr>, VariantProps<typeof StyledTr> {
   children: React.ReactNode;
   collapsedContent?: React.ReactNode;
   emptyFirstColumn?: boolean;
   tableHead?: boolean;
-  css?: CSS;
-}) => {
-  const [isCollapsed, setIsCollapsed] = useState(false);
+}
 
-  return (
-    <>
-      <StyledTr {...props}>
-        {emptyFirstColumn ? tableHead ? <Th css={{ width: 24 }} /> : <Td /> : null}
-        {!!collapsedContent && (
-          <Td>
-            <Box
-              onClick={(e) => {
-                e.stopPropagation();
-                e.preventDefault();
-              }}
-            >
-              <ChevronRightIcon
-                onClick={() => setIsCollapsed(!isCollapsed)}
-                style={{
-                  cursor: 'pointer',
-                  transition: 'transform 0.2s ease-out',
-                  transform: isCollapsed ? 'rotate(90deg)' : 'initial',
+export const Tr = forwardRef<ElementRef<typeof StyledTr>, TrProps>(
+  ({ children, collapsedContent, emptyFirstColumn = false, tableHead = false, ...props }, ref) => {
+    const [isCollapsed, setIsCollapsed] = useState(false);
+
+    return (
+      <>
+        <StyledTr {...props}>
+          {emptyFirstColumn ? tableHead ? <Th css={{ width: 24 }} /> : <Td /> : null}
+          {!!collapsedContent && (
+            <Td>
+              <Box
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
                 }}
-              />
-            </Box>
-          </Td>
+              >
+                <ChevronRightIcon
+                  onClick={() => setIsCollapsed(!isCollapsed)}
+                  style={{
+                    cursor: 'pointer',
+                    transition: 'transform 0.2s ease-out',
+                    transform: isCollapsed ? 'rotate(90deg)' : 'initial',
+                  }}
+                />
+              </Box>
+            </Td>
+          )}
+          {children}
+        </StyledTr>
+        {!!collapsedContent && (
+          <RenderedCollapsedContent isOpen={isCollapsed}>
+            {collapsedContent}
+          </RenderedCollapsedContent>
         )}
-        {children}
-      </StyledTr>
-      {!!collapsedContent && (
-        <RenderedCollapsedContent isOpen={isCollapsed}>{collapsedContent}</RenderedCollapsedContent>
-      )}
-    </>
-  );
-};
+      </>
+    );
+  }
+);
 
 export const Tfoot = styled('tfoot', {
   verticalAlign: 'middle',

--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -1,7 +1,11 @@
+import { ChevronDownIcon, ChevronRightIcon } from '@radix-ui/react-icons';
+import { CSS, keyframes } from '@stitches/react';
+import { Children, cloneElement, useState, useMemo } from 'react';
 import { styled, VariantProps } from '../../stitches.config';
 import { elevationVariants } from '../Elevation';
 import { Label } from '../Label';
 import { Text } from '../Text';
+import { Box } from '../Box';
 
 export const Caption = styled('caption', Text, {
   display: 'table-caption',
@@ -82,7 +86,7 @@ export const Td = styled('td', {
   },
 });
 
-export const Tr = styled('tr', {
+const StyledTr = styled('tr', {
   verticalAlign: 'inherit',
   '&:hover': {
     color: '$tableHoverText',
@@ -120,6 +124,71 @@ export const Tr = styled('tr', {
     },
   ],
 });
+
+const RenderedCollapsedContent = ({ isOpen, children }) => {
+  const renderedChildren = useMemo(() => {
+    return Children.map(children.props.children, (child) =>
+      cloneElement(child, {
+        style: isOpen
+          ? {
+              ...child.props.style,
+              transition: 'padding 0.2s ease-out',
+            }
+          : {
+              ...child.props.style,
+              transition: 'padding 0.2s ease-out',
+              lineHeight: 0,
+              fontSize: 0,
+              padding: '0px 16px',
+            },
+      })
+    );
+  }, [isOpen, children]);
+
+  return <Tr>{renderedChildren}</Tr>;
+};
+
+export const Tr = ({
+  children,
+  collapsedContent,
+  ...props
+}: VariantProps<typeof StyledTr> & {
+  children: React.ReactNode;
+  collapsedContent?: React.ReactNode;
+  css?: CSS;
+}) => {
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  return (
+    <>
+      <StyledTr {...props}>
+        {!!collapsedContent && (
+          <Td>
+            <Box
+              onClick={(e) => {
+                e.stopPropagation();
+                e.preventDefault();
+              }}
+            >
+              <ChevronRightIcon
+                onClick={() => setIsCollapsed(!isCollapsed)}
+                style={{
+                  cursor: 'pointer',
+                  transition: 'transform 0.2s ease-out',
+                  transform: isCollapsed ? 'rotate(90deg)' : 'initial',
+                }}
+              />
+            </Box>
+          </Td>
+        )}
+        {children}
+      </StyledTr>
+      {!!collapsedContent && (
+        <RenderedCollapsedContent isOpen={isCollapsed}>{collapsedContent}</RenderedCollapsedContent>
+      )}
+    </>
+  );
+};
 
 export const Tfoot = styled('tfoot', {
   verticalAlign: 'middle',

--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -126,26 +126,37 @@ const StyledTr = styled('tr', {
 });
 
 const RenderedCollapsedContent = ({ isOpen, children }) => {
+  return Children.map(children.props.children, (child) => {
+    return <AnimatedTr isOpen={isOpen}>{child}</AnimatedTr>;
+  });
+};
+
+const AnimatedTr = ({ isOpen, children }) => {
+  const appliedStyle = useMemo(
+    () =>
+      isOpen
+        ? { transition: 'padding 0.2s ease-out' }
+        : { transition: 'padding 0.2s ease-out', lineHeight: 0, fontSize: 0, padding: '0px 16px' },
+    [isOpen]
+  );
+
   const renderedChildren = useMemo(() => {
     return Children.map(children.props.children, (child) =>
       cloneElement(child, {
-        style: isOpen
-          ? {
-              ...child.props.style,
-              transition: 'padding 0.2s ease-out',
-            }
-          : {
-              ...child.props.style,
-              transition: 'padding 0.2s ease-out',
-              lineHeight: 0,
-              fontSize: 0,
-              padding: '0px 16px',
-            },
+        style: {
+          ...child.props.style,
+          ...appliedStyle,
+        },
       })
     );
-  }, [isOpen, children]);
+  }, [children, isOpen]);
 
-  return <Tr>{renderedChildren}</Tr>;
+  return (
+    <Tr>
+      <Td css={appliedStyle} />
+      {renderedChildren}
+    </Tr>
+  );
 };
 
 export const Tr = ({

--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -162,10 +162,14 @@ const AnimatedTr = ({ isOpen, children }) => {
 export const Tr = ({
   children,
   collapsedContent,
+  emptyFirstColumn = false,
+  tableHead = false,
   ...props
 }: VariantProps<typeof StyledTr> & {
   children: React.ReactNode;
   collapsedContent?: React.ReactNode;
+  emptyFirstColumn?: boolean;
+  tableHead?: boolean;
   css?: CSS;
 }) => {
   const [isCollapsed, setIsCollapsed] = useState(false);
@@ -173,6 +177,7 @@ export const Tr = ({
   return (
     <>
       <StyledTr {...props}>
+        {emptyFirstColumn ? tableHead ? <Th css={{ width: 24 }} /> : <Td /> : null}
         {!!collapsedContent && (
           <Td>
             <Box

--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -1,5 +1,4 @@
-import { ChevronDownIcon, ChevronRightIcon } from '@radix-ui/react-icons';
-import { CSS, keyframes } from '@stitches/react';
+import { ChevronRightIcon } from '@radix-ui/react-icons';
 import {
   Children,
   cloneElement,
@@ -8,6 +7,7 @@ import {
   forwardRef,
   ElementRef,
   ComponentProps,
+  ElementType,
 } from 'react';
 import { styled, VariantProps } from '../../stitches.config';
 import { elevationVariants } from '../Elevation';
@@ -133,13 +133,36 @@ export const StyledTr = styled('tr', {
   ],
 });
 
-const RenderedCollapsedContent = ({ isOpen, children }) => {
+type CollapsedContentProps = {
+  isOpen: boolean;
+  TrComponent: ElementType;
+  TdComponent?: ElementType;
+  children: any;
+};
+
+export const RenderedCollapsedContent = ({
+  isOpen,
+  children,
+  TrComponent,
+  TdComponent = Td,
+}: CollapsedContentProps) => {
   return Children.map(children.props.children, (child) => {
-    return <AnimatedTr isOpen={isOpen}>{child}</AnimatedTr>;
+    return (
+      <AnimatedTr isOpen={isOpen} TrComponent={TrComponent} TdComponent={TdComponent}>
+        {child}
+      </AnimatedTr>
+    );
   });
 };
 
-const AnimatedTr = ({ isOpen, children }) => {
+const AnimatedTr = ({
+  isOpen,
+  TrComponent,
+  TdComponent,
+  children,
+}: CollapsedContentProps & {
+  TdComponent: ElementType;
+}) => {
   const appliedStyle = useMemo(
     () =>
       isOpen
@@ -166,10 +189,10 @@ const AnimatedTr = ({ isOpen, children }) => {
   }, [children, isOpen]);
 
   return (
-    <Tr>
-      <Td css={appliedStyle} />
+    <TrComponent>
+      <TdComponent css={appliedStyle} />
       {renderedChildren}
-    </Tr>
+    </TrComponent>
   );
 };
 export interface TrProps extends ComponentProps<typeof StyledTr>, VariantProps<typeof StyledTr> {
@@ -209,7 +232,7 @@ export const Tr = forwardRef<ElementRef<typeof StyledTr>, TrProps>(
           {children}
         </StyledTr>
         {!!collapsedContent && (
-          <RenderedCollapsedContent isOpen={isCollapsed}>
+          <RenderedCollapsedContent isOpen={isCollapsed} TrComponent={Tr}>
             {collapsedContent}
           </RenderedCollapsedContent>
         )}

--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -179,7 +179,7 @@ export const Tr = forwardRef<ElementRef<typeof StyledTr>, TrProps>(
 
     return (
       <>
-        <StyledTr {...props}>
+        <StyledTr ref={ref} {...props}>
           {emptyFirstColumn ? tableHead ? <Th css={{ width: 24 }} /> : <Td /> : null}
           {!!collapsedContent && (
             <Td>


### PR DESCRIPTION
## Description

- Fixes https://github.com/traefik/faency/issues/414

Add new properties for `<Tr />` and `<AriaTr />` that will permit user to have a collapsible row under it.
User can add `collapsibleContent` property on their `Tr` component, and it will be rendered as an additional row underneath it.

The header row should also be adjusted with `emptyFirstColumn` and `tableHead` properties to keep it aligned with the content, as the chevron indicator will take space in the first column.

## Preview

https://github.com/traefik/faency/assets/70909035/40514324-4b6f-41b3-8d83-6993b0448794


## Good PR checkboxes

- [ ] Change has been tested
- [ ] Added/Updated tests
- [ ] Added/Updated stories
- [ ] PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
- [ ] Labels are set
- [ ] Project is linked

## Good Review checkboxes

<details>
<summary> ℹ️  Copy the snippet and paste in the review field to fill it</summary>

```markdown
- [ ] I've tested the changes
- [ ] I've agreed on the unit tests (soon to come)
- [ ] I've checked the stories
- [ ] I've read the code and understood it
- [ ] I don't have any more questions
- [ ] I've described any optional improvements
- [ ] I checked PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
```

</details>
