### PR TITLE
fix: consider only direct parent for radio accordion's state

### DIFF
--- a/components/RadioAccordion/RadioAccordion.stories.tsx
+++ b/components/RadioAccordion/RadioAccordion.stories.tsx
@@ -8,6 +8,8 @@ import {
   RadioAccordionTrigger,
 } from './RadioAccordion';
 import { Box } from '../Box';
+import { AccordionContent, AccordionItem, AccordionRoot, AccordionTrigger } from '../Accordion';
+import { Text } from '../Text';
 
 export default {
   title: 'Components/RadioAccordion',
@@ -31,6 +33,32 @@ export const Basic: ComponentStory<typeof RadioAccordionRoot> = (args) => (
       </RadioAccordionItem>
     </RadioAccordionRoot>
   </Box>
+);
+
+export const UnderAccordion: ComponentStory<typeof RadioAccordionRoot> = (args) => (
+  <AccordionRoot type="single" collapsible>
+    <AccordionItem value="default" css={{ boxShadow: 'none' }}>
+      <AccordionTrigger>
+        <Text>Open the accordion</Text>
+      </AccordionTrigger>
+      <AccordionContent>
+        <RadioAccordionRoot {...args}>
+          <RadioAccordionItem value="item-1">
+            <RadioAccordionTrigger>Item1 Trigger</RadioAccordionTrigger>
+            <RadioAccordionContent>Item1 Content</RadioAccordionContent>
+          </RadioAccordionItem>
+          <RadioAccordionItem value="item-2">
+            <RadioAccordionTrigger>Item2 Trigger</RadioAccordionTrigger>
+            <RadioAccordionContent>Item2 Content</RadioAccordionContent>
+          </RadioAccordionItem>
+          <RadioAccordionItem value="item-3">
+            <RadioAccordionTrigger>Item3 Trigger</RadioAccordionTrigger>
+            <RadioAccordionContent>Item3 Content</RadioAccordionContent>
+          </RadioAccordionItem>
+        </RadioAccordionRoot>
+      </AccordionContent>
+    </AccordionItem>
+  </AccordionRoot>
 );
 
 const Customize: ComponentStory<typeof RadioAccordionRoot> = (args) => (

--- a/components/RadioAccordion/RadioAccordion.tsx
+++ b/components/RadioAccordion/RadioAccordion.tsx
@@ -46,7 +46,7 @@ const StyledRadio = styled('div', RADIO_BASE_STYLES, {
   width: 18,
   height: 18,
   mr: '$2',
-  '[data-state=open] &': {
+  '[data-state=open] > &': {
     backgroundColor: '$radioIndicator',
   },
 });


### PR DESCRIPTION
## Description

Radio button's under an accordion will take the parent accordion component's state into consideration, so if the accordion is open, the button state is always checked.

Related to https://github.com/traefik/hub-issues/issues/912.

## Preview

Before: 

https://github.com/traefik/faency/assets/70909035/c1cb5f38-ff44-4cea-a006-4cde6d970a8d


After:

https://github.com/traefik/faency/assets/70909035/4da26103-7644-41c2-be8f-77450e8f1485


## How to test?

<!--
If you consider the change needs specific instructions on how to test, use this section to describe it step-by-step.
-->

1. Go to the page ...
2. Click on ...

## Good PR checkboxes

- [ ] Change has been tested
- [ ] Added/Updated tests
- [ ] Added/Updated stories
- [ ] PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
- [ ] Labels are set
- [ ] Project is linked

## Good Review checkboxes

<details>
<summary> ℹ️  Copy the snippet and paste in the review field to fill it</summary>

```markdown
- [ ] I've tested the changes
- [ ] I've agreed on the unit tests (soon to come)
- [ ] I've checked the stories
- [ ] I've read the code and understood it
- [ ] I don't have any more questions
- [ ] I've described any optional improvements
- [ ] I checked PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
```

</details>
