### PR TITLE
fix: do not force display as table-row

### DIFF
--- a/components/AriaTable/AriaTable.tsx
+++ b/components/AriaTable/AriaTable.tsx
@@ -161,7 +161,7 @@ export const Tr = forwardRef<ElementRef<typeof StyledTr>, TrProps>(
           children as any,
           {
             // @ts-ignore: Object is possibly 'null'.
-            style: { ...children?.props?.style, display: 'table-row' },
+            ...children?.props,
           },
           // @ts-ignore: Object is possibly 'null'.
           [TdEl, ...children?.props?.children]


### PR DESCRIPTION
## Description

For table row with `asChild` set as true, we were forcing the `display: table-row` on it. This could mess up the display for elements that has a custom display value set. This PR removes this behavior to set the `display` value.

## Preview

No visual change, please check the `Links` story under AriaTable to see if there were any undesirable side effects.

