### PR TITLE
feat: fullwidth variant for navigation

### DIFF
--- a/components/Navigation/Navigation.stories.tsx
+++ b/components/Navigation/Navigation.stories.tsx
@@ -26,6 +26,9 @@ export default {
     elevation: {
       control: 'number',
     },
+    fullWidth: {
+      control: 'boolean',
+    },
   },
 } as ComponentMeta<typeof NavigationDrawer>;
 
@@ -65,6 +68,7 @@ export const Basic = Template.bind({});
 
 Basic.args = {
   elevation: 1,
+  fullWidth: false,
 };
 
 const AdornmentsTemplate: ComponentStory<typeof NavigationDrawerForStory> = (args) => {

--- a/components/Navigation/Navigation.tsx
+++ b/components/Navigation/Navigation.tsx
@@ -114,6 +114,28 @@ const baseNavItemCss = css({
         },
       },
     },
+    fullWidth: {
+      true: {
+        px: 0,
+        borderRadius: 0,
+
+        '&::before': {
+          borderRadius: 0,
+          left: '-$3',
+          right: '-$3',
+        },
+
+        '&::after': {
+          borderRadius: 0,
+          left: '-$3',
+          right: '-$3',
+        },
+      },
+    },
+  },
+  defaultVariants: {
+    active: false,
+    fullWidth: false,
   },
 });
 

--- a/components/Navigation/Navigation.tsx
+++ b/components/Navigation/Navigation.tsx
@@ -140,7 +140,7 @@ export const NavigationDrawer = styled('nav', {
     fullWidth: {
       true: {
         px: 0,
-        '> *': {
+        '> *, > div > *,': {
           borderRadius: 0,
 
           '&::before': {

--- a/components/Navigation/Navigation.tsx
+++ b/components/Navigation/Navigation.tsx
@@ -114,28 +114,9 @@ const baseNavItemCss = css({
         },
       },
     },
-    fullWidth: {
-      true: {
-        px: 0,
-        borderRadius: 0,
-
-        '&::before': {
-          borderRadius: 0,
-          left: '-$3',
-          right: '-$3',
-        },
-
-        '&::after': {
-          borderRadius: 0,
-          left: '-$3',
-          right: '-$3',
-        },
-      },
-    },
   },
   defaultVariants: {
     active: false,
-    fullWidth: false,
   },
 });
 
@@ -156,9 +137,26 @@ export const NavigationDrawer = styled('nav', {
   flexDirection: 'column',
   variants: {
     elevation: elevationVariants,
+    fullWidth: {
+      true: {
+        px: 0,
+        '> *': {
+          borderRadius: 0,
+
+          '&::before': {
+            borderRadius: 0,
+          },
+
+          '&::after': {
+            borderRadius: 0,
+          },
+        },
+      },
+    },
   },
   defaultVariants: {
     elevation: 1,
+    fullWidth: false,
   },
 });
 

--- a/components/Navigation/Navigation.tsx
+++ b/components/Navigation/Navigation.tsx
@@ -150,6 +150,11 @@ export const NavigationDrawer = styled('nav', {
           '&::after': {
             borderRadius: 0,
           },
+
+          '&:focus': {
+            border: 'none',
+            boxShadow: 'none',
+          },
         },
       },
     },

--- a/components/Navigation/NavigationItem.stories.tsx
+++ b/components/Navigation/NavigationItem.stories.tsx
@@ -41,6 +41,9 @@ export default {
     active: {
       control: 'boolean',
     },
+    fullWidth: {
+      control: 'boolean',
+    },
   },
 } as ComponentMeta<typeof NavigationDrawer>;
 
@@ -84,6 +87,7 @@ Basic.args = {
   startAdornment: 'Gear',
   endAdornment: 1,
   active: false,
+  fullWidth: false,
 };
 
 export const ButtonProps: ComponentStory<typeof NavigationItem> = (args) => {

--- a/components/Navigation/NavigationItem.stories.tsx
+++ b/components/Navigation/NavigationItem.stories.tsx
@@ -41,9 +41,6 @@ export default {
     active: {
       control: 'boolean',
     },
-    fullWidth: {
-      control: 'boolean',
-    },
   },
 } as ComponentMeta<typeof NavigationDrawer>;
 
@@ -87,7 +84,6 @@ Basic.args = {
   startAdornment: 'Gear',
   endAdornment: 1,
   active: false,
-  fullWidth: false,
 };
 
 export const ButtonProps: ComponentStory<typeof NavigationItem> = (args) => {

--- a/components/NavigationTree/NavigationTree.stories.tsx
+++ b/components/NavigationTree/NavigationTree.stories.tsx
@@ -93,3 +93,74 @@ const Template: ComponentStory<typeof NavigationTreeContainer> = (args) => {
 export const Basic = Template.bind({});
 
 Basic.args = {};
+
+const FullWidthStory: ComponentStory<typeof NavigationTreeContainer> = (args) => {
+  const [currentRoute, setCurrentRoute] = useState('/');
+
+  const navigationHandlerProps = (route: string) => ({
+    active: route === currentRoute,
+    onClick: () => setCurrentRoute(route),
+  });
+
+  return (
+    <NavigationDrawer fullWidth>
+      <NavigationTreeContainer {...args}>
+        <NavigationTreeItem {...navigationHandlerProps('one')} label="One" subtitle="/one">
+          <NavigationTreeItem
+            {...navigationHandlerProps('one-one')}
+            as="a"
+            label="One.One"
+            subtitle="/one-one"
+          />
+          <NavigationTreeItem
+            {...navigationHandlerProps('one-two')}
+            label="One.Two"
+            nestedLevel={1}
+          >
+            <NavigationTreeItem
+              {...navigationHandlerProps('one-two-one')}
+              startAdornment={<ArchiveIcon />}
+              label="One.Two.One"
+            />
+          </NavigationTreeItem>
+        </NavigationTreeItem>
+        <NavigationTreeItem
+          {...navigationHandlerProps('two')}
+          label="Two"
+          subtitle="/two"
+          defaultExpanded
+        >
+          <NavigationTreeItem
+            {...navigationHandlerProps('two-one')}
+            as="a"
+            label="Two.One"
+            subtitle="/two-one"
+          />
+          <NavigationTreeItem
+            {...navigationHandlerProps('two-two')}
+            label="Two.Two"
+            subtitle="/two-two"
+            nestedLevel={1}
+          >
+            <NavigationTreeItem
+              {...navigationHandlerProps('two-two-one')}
+              label="Two.Two.One"
+              nestedLevel={2}
+            >
+              <NavigationTreeItem
+                {...navigationHandlerProps('two-two-one-one')}
+                startAdornment={<ArchiveIcon />}
+                label="Two.Two.One.One"
+              />
+            </NavigationTreeItem>
+          </NavigationTreeItem>
+        </NavigationTreeItem>
+        <NavigationTreeItem {...navigationHandlerProps('three')} label="Three" />
+      </NavigationTreeContainer>
+    </NavigationDrawer>
+  );
+};
+
+export const FullWidth = FullWidthStory.bind({});
+
+FullWidth.args = {};

--- a/components/NavigationTree/NavigationTree.stories.tsx
+++ b/components/NavigationTree/NavigationTree.stories.tsx
@@ -115,7 +115,7 @@ const FullWidthStory: ComponentStory<typeof NavigationTreeContainer> = (args) =>
           <NavigationTreeItem
             {...navigationHandlerProps('one-two')}
             label="One.Two"
-            nestedLevel={1}
+            nestedChildrenLevel={1}
           >
             <NavigationTreeItem
               {...navigationHandlerProps('one-two-one')}
@@ -140,12 +140,12 @@ const FullWidthStory: ComponentStory<typeof NavigationTreeContainer> = (args) =>
             {...navigationHandlerProps('two-two')}
             label="Two.Two"
             subtitle="/two-two"
-            nestedLevel={1}
+            nestedChildrenLevel={1}
           >
             <NavigationTreeItem
               {...navigationHandlerProps('two-two-one')}
               label="Two.Two.One"
-              nestedLevel={2}
+              nestedChildrenLevel={2}
             >
               <NavigationTreeItem
                 {...navigationHandlerProps('two-two-one-one')}

--- a/components/NavigationTree/NavigationTree.stories.tsx
+++ b/components/NavigationTree/NavigationTree.stories.tsx
@@ -104,7 +104,7 @@ const FullWidthStory: ComponentStory<typeof NavigationTreeContainer> = (args) =>
 
   return (
     <NavigationDrawer fullWidth>
-      <NavigationTreeContainer {...args}>
+      <NavigationTreeContainer fullWidth {...args}>
         <NavigationTreeItem {...navigationHandlerProps('one')} label="One" subtitle="/one">
           <NavigationTreeItem
             {...navigationHandlerProps('one-one')}

--- a/components/NavigationTree/NavigationTreeContainer.tsx
+++ b/components/NavigationTree/NavigationTreeContainer.tsx
@@ -8,18 +8,21 @@ export interface TreeViewProps {
   defaultExpandIcon?: React.ReactNode;
   defaultCollapseIcon?: React.ReactNode;
   css?: CSS;
+  fullWidth?: boolean;
 }
 
 export const NavigationTreeContainer = ({
   children,
   defaultCollapseIcon = <ChevronDownIcon />,
   defaultExpandIcon = <ChevronRightIcon />,
+  fullWidth = false,
   ...props
 }: TreeViewProps & NavigationContainerProps) => {
   const renderChildren = React.Children.map(children, (child) => {
     return React.cloneElement(child as React.ReactElement, {
       defaultCollapseIcon,
       defaultExpandIcon,
+      fullWidth,
     });
   });
   return <NavigationContainer {...props}>{renderChildren}</NavigationContainer>;

--- a/components/NavigationTree/NavigationTreeItem.tsx
+++ b/components/NavigationTree/NavigationTreeItem.tsx
@@ -17,6 +17,7 @@ export interface NavigationTreeItemProps {
   customExpandIcon?: React.ReactNode;
   customCollapseIcon?: React.ReactNode;
   nestedLevel?: number;
+  fullWidth?: boolean;
 }
 
 export const NavigationTreeItem = ({
@@ -30,6 +31,7 @@ export const NavigationTreeItem = ({
   customCollapseIcon,
   customExpandIcon,
   nestedLevel = 0,
+  fullWidth = false,
   ...props
 }: NavigationTreeItemProps & NavigationItemProps) => {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
@@ -63,7 +65,7 @@ export const NavigationTreeItem = ({
       pl: '$4',
       '> div > *': {
         '&::before, &::after': {
-          left: `calc(${nestedLevel + 1} * -20px)`,
+          left: fullWidth ? `calc(${nestedLevel + 1} * -20px)` : 0,
         },
       },
     };
@@ -93,9 +95,9 @@ export const NavigationTreeItem = ({
       </NavigationItem>
       {isExpanded && (
         <NavigationTreeContainer
-          key={label}
           defaultCollapseIcon={defaultCollapseIcon}
           defaultExpandIcon={defaultExpandIcon}
+          fullWidth={fullWidth}
           css={childCss as CSS}
         >
           {children}

--- a/components/NavigationTree/NavigationTreeItem.tsx
+++ b/components/NavigationTree/NavigationTreeItem.tsx
@@ -4,6 +4,7 @@ import { NavigationItem, NavigationItemProps } from '../Navigation';
 import { NavigationTreeContainer } from './NavigationTreeContainer';
 import { Flex } from '../Flex';
 import { Text } from '../Text';
+import { CSS } from '../..';
 
 export interface NavigationTreeItemProps {
   label: string;
@@ -15,6 +16,7 @@ export interface NavigationTreeItemProps {
   defaultCollapseIcon?: React.ReactNode;
   customExpandIcon?: React.ReactNode;
   customCollapseIcon?: React.ReactNode;
+  nestedLevel?: number;
 }
 
 export const NavigationTreeItem = ({
@@ -27,6 +29,7 @@ export const NavigationTreeItem = ({
   defaultExpandIcon,
   customCollapseIcon,
   customExpandIcon,
+  nestedLevel = 0,
   ...props
 }: NavigationTreeItemProps & NavigationItemProps) => {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
@@ -53,6 +56,19 @@ export const NavigationTreeItem = ({
     ]
   );
 
+  const childCss = useMemo(() => {
+    if (!isExpandable) return null;
+
+    return {
+      pl: '$4',
+      '> div > *': {
+        '&::before, &::after': {
+          left: `calc(${nestedLevel + 1} * -20px)`,
+        },
+      },
+    };
+  }, [isExpandable, nestedLevel]);
+
   return (
     <Box>
       <NavigationItem
@@ -77,9 +93,10 @@ export const NavigationTreeItem = ({
       </NavigationItem>
       {isExpanded && (
         <NavigationTreeContainer
+          key={label}
           defaultCollapseIcon={defaultCollapseIcon}
           defaultExpandIcon={defaultExpandIcon}
-          css={{ ml: '$4' }}
+          css={childCss as CSS}
         >
           {children}
         </NavigationTreeContainer>

--- a/components/NavigationTree/NavigationTreeItem.tsx
+++ b/components/NavigationTree/NavigationTreeItem.tsx
@@ -16,7 +16,7 @@ export interface NavigationTreeItemProps {
   defaultCollapseIcon?: React.ReactNode;
   customExpandIcon?: React.ReactNode;
   customCollapseIcon?: React.ReactNode;
-  nestedLevel?: number;
+  nestedChildrenLevel?: number;
   fullWidth?: boolean;
 }
 
@@ -30,7 +30,7 @@ export const NavigationTreeItem = ({
   defaultExpandIcon,
   customCollapseIcon,
   customExpandIcon,
-  nestedLevel = 0,
+  nestedChildrenLevel = 0,
   fullWidth = false,
   ...props
 }: NavigationTreeItemProps & NavigationItemProps) => {
@@ -65,11 +65,11 @@ export const NavigationTreeItem = ({
       pl: '$4',
       '> div > *': {
         '&::before, &::after': {
-          left: fullWidth ? `calc(${nestedLevel + 1} * -20px)` : 0,
+          left: fullWidth ? `calc(${nestedChildrenLevel + 1} * -20px)` : 0,
         },
       },
     };
-  }, [isExpandable, nestedLevel]);
+  }, [isExpandable, nestedChildrenLevel]);
 
   return (
     <Box>


### PR DESCRIPTION
## Description

Related to https://github.com/traefik/hub-issues/issues/982.

To combine the styles between our current UI and stoplight element seamlessly, we will need to make it possible to make navigation items to take the whole width (visually) on hover and focus.

`fullWidth` props added on the nav drawer and container level.

Tricky part is with navigation tree. I haven't find the most beautiful solution yet, for the moment it works the same, `fullWidth` on drawer and NavigationTreeContainer, and for item that is nesting other elements, user will have to add context about in which level is this element's children nested.

Example:
```
<NavigationDrawer fullWidth>
      <NavigationTreeContainer fullWidth {...args}>
        <NavigationTreeItem {...navigationHandlerProps('one')} label="One" subtitle="/one"> {/** LEVEL 0 */}
          <NavigationTreeItem   -------------------------------------------------------->   {/** LEVEL 1 */}
            {...navigationHandlerProps('one-one')}
            as="a"
            label="One.One"
            subtitle="/one-one"
          />
          <NavigationTreeItem ------------------------------------------------------------> {/** LEVEL 1 */}
            {...navigationHandlerProps('one-two')}
            label="One.Two"
            nestedChildrenLevel={2}
          >
            <NavigationTreeItem ----------------------------------------------------------> {/** LEVEL 2 */}
              {...navigationHandlerProps('one-two-one')}
              startAdornment={<ArchiveIcon />}
              label="One.Two.One"
            />
          </NavigationTreeItem>
        </NavigationTreeItem>
      </NavigationTreeContainer>
    </NavigationDrawer>
```

The `nestedChildrenLevel` should specify in which level the children are. This is only needed if the NavTreeItem has children, that is why I opted to take `nestedChildrenLevel` instead of the element's level itself. But please let me know if you have any input to make it clearer on how to use and makes more sense. Default value is 1.

## Preview

https://github.com/traefik/faency/assets/70909035/577f9056-c4a0-401b-8d0b-b500b0e88429

