### PR TITLE
feat!: borderless badge variant

### DIFF
--- a/components/Badge/Badge.stories.tsx
+++ b/components/Badge/Badge.stories.tsx
@@ -18,6 +18,7 @@ export default {
   argTypes: {
     size: { control: 'inline-radio' },
     variant: { control: 'select' },
+    borderless: { control: 'boolean' },
   },
 } as ComponentMeta<typeof BadgeForStory>;
 
@@ -36,6 +37,7 @@ Colors.args = {
   interactive: false,
   size: 'small',
   variant: 'gray',
+  borderless: false,
 };
 
 export const AlphaBackground = Colors.bind({});
@@ -52,6 +54,7 @@ Small.args = {
   interactive: false,
   size: 'small',
   variant: 'blue',
+  borderless: false,
 };
 
 export const Large: ComponentStory<typeof BadgeForStory> = (args) => (
@@ -62,6 +65,7 @@ Large.args = {
   interactive: false,
   size: 'large',
   variant: 'green',
+  borderless: false,
 };
 
 export const Interactive: ComponentStory<typeof BadgeForStory> = (args) => (
@@ -79,6 +83,7 @@ Interactive.args = {
   interactive: true,
   size: 'small',
   variant: 'gray',
+  borderless: false,
 };
 
 const Customize: ComponentStory<typeof BadgeForStory> = (args) => (
@@ -92,3 +97,14 @@ export const BadgeLink: ComponentStory<typeof BadgeForStory> = (args) => (
     <UnstyledLink href="https://traefik.io">Link</UnstyledLink>
   </Badge>
 );
+
+export const Borderless: ComponentStory<typeof BadgeForStory> = (args) => (
+  <Badge {...args}>Borderless badge</Badge>
+);
+
+Borderless.args = {
+  interactive: true,
+  size: 'small',
+  variant: 'neon',
+  borderless: true,
+};

--- a/components/Badge/Badge.tsx
+++ b/components/Badge/Badge.tsx
@@ -8,6 +8,7 @@ type COLOR_VALUES = typeof COLORS[number];
 const getColorBadgeStyles = (color: COLOR_VALUES) => ({
   bc: `$${color}6`,
   color: `$${color}10`,
+  border: `1px solid $${color}10`,
 });
 
 type ColorVariants = Record<COLOR_VALUES, { bc: string; color: string }>;
@@ -79,6 +80,11 @@ const BADGE_BASE_STYLES = {
     variant: colorVariants,
     alphaBg: {
       true: {},
+    },
+    borderless: {
+      true: {
+        border: 'none',
+      },
     },
   },
   compoundVariants: alphaColorCompoundVariants,

--- a/components/Badge/Badge.tsx
+++ b/components/Badge/Badge.tsx
@@ -91,6 +91,7 @@ const BADGE_BASE_STYLES = {
   defaultVariants: {
     size: 'small',
     variant: 'gray',
+    borderless: false,
   },
 };
 
@@ -122,6 +123,11 @@ const StyledButtonBadge = styled('button', BADGE_BASE_STYLES, {
 
   variants: {
     variant: interactiveColorVariants,
+    borderless: {
+      true: {
+        border: 'none',
+      },
+    },
   },
 });
 const StyledButtonBadgeSlot = styled(Slot, StyledButtonBadge);


### PR DESCRIPTION
## Description

Currently, our badge does not have border, it only has background color defined. To fulfill specification needed for https://github.com/traefik/hub-issues/issues/977, border will need to be added to badges. This PR add a new `borderless` variant for badges. By default, badges will have border.

Related to https://github.com/traefik/hub-ui/pull/1081

## Preview

https://github.com/traefik/faency/assets/70909035/2eb0741d-2de3-4b1f-812f-4d052812d36a


## Breaking changes

By default, badge will have border. If badge with no border still expected, `borderless` variant needs to be added to the `<Badge />` component.
