### PR TITLE
fix: inner card background color for light mode

### DIFF
--- a/components/Card/Card.themes.ts
+++ b/components/Card/Card.themes.ts
@@ -25,6 +25,7 @@ export namespace Theme {
     cardActiveBackground: 'rgba(0,0,0,.03)',
     cardActiveBorder: '$primary',
     cardGhostBackground: '$deepBlue2',
+    innerCardBgColor: tinycolor('black').setAlpha(0.04).toHslString(),
   });
 
   export const getDark: Factory = (primaryColor) => ({
@@ -36,5 +37,6 @@ export namespace Theme {
     cardActiveBackground: 'rgba(255,255,255,.07)',
     cardActiveBorder: tinycolor(primaryColor.value).setAlpha(0.4).toHslString(),
     cardGhostBackground: '$deepBlue1',
+    innerCardBgColor: tinycolor('white').setAlpha(0.07).toHslString(),
   });
 }

--- a/components/Card/Card.tsx
+++ b/components/Card/Card.tsx
@@ -37,7 +37,7 @@ const StyledCard = styled('div', {
     elevation: elevationVariants,
     variant: {
       inner: {
-        backgroundColor: 'rgba(255,255,255,.07)',
+        backgroundColor: '$innerCardBgColor',
       },
       ghost: {
         backgroundColor: 'transparent',


### PR DESCRIPTION
## Description

The current background color for inner card is a white color with adjusted alpha. It makes difference on dark mode, but doesn't really do anything on light mode. This PR fixes the background color for `Card` component with `inner` variant.

Related to https://github.com/traefik/hub-ui/pull/1081.

## Preview

![image](https://github.com/traefik/faency/assets/70909035/d639251d-9ea3-48ac-aef0-ca17e1cb51f7)
