### PR TITLE
feat: wider clickable area in collapsible table row

### DIFF
--- a/components/Table/Table.tsx
+++ b/components/Table/Table.tsx
@@ -217,16 +217,15 @@ export const Tr = forwardRef<ElementRef<typeof StyledTr>, TrProps>(
         >
           {emptyFirstColumn ? tableHead ? <Th css={{ width: 24 }} /> : <Td /> : null}
           {!!collapsedContent && (
-            <Td>
-              <Flex
-                align="center"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  e.preventDefault();
-                }}
-              >
+            <Td
+              css={{ paddingRight: 0 }}
+              onClick={(e) => {
+                e.stopPropagation();
+                e.preventDefault();
+              }}
+            >
+              <Flex align="center" justify="center" onClick={() => setIsCollapsed(!isCollapsed)}>
                 <ChevronRightIcon
-                  onClick={() => setIsCollapsed(!isCollapsed)}
                   style={{
                     cursor: 'pointer',
                     transition: 'transform 0.2s ease-out',


### PR DESCRIPTION
## Description

This PR makes the area around the "expand me" chevron clickable in collapsible table row, and centers the chevron in its column.

Fixes https://github.com/traefik/hub-issues/issues/1084

## Preview

![Screenshot 2024-01-25 alle 14 58 05](https://github.com/traefik/faency/assets/126668030/b0fa35a0-71fd-4aa1-bea3-4fd16bbb47b4)

## Good PR checkboxes

- [x] Change has been tested
- [ ] Added/Updated tests
- [ ] Added/Updated stories
- [x] PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
- [x] Labels are set
- [x] Project is linked

## Good Review checkboxes

<details>
<summary> ℹ️  Copy the snippet and paste in the review field to fill it</summary>

```markdown
- [ ] I've tested the changes
- [ ] I've agreed on the unit tests (soon to come)
- [ ] I've checked the stories
- [ ] I've read the code and understood it
- [ ] I don't have any more questions
- [ ] I've described any optional improvements
- [ ] I checked PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
```

</details>
