### PR TITLE
chore: use yarn on release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,13 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Install dependencies
-        run: npm ci
+        run: yarn --frozen-lockfile
 
       - name: Build
-        run: npm run build
+        run: yarn build
 
       - name: Release
         run: npx semantic-release


### PR DESCRIPTION
## Description

There is no more `package-lock.json` after the last update; therefore, `npm ci` command could not run anymore.