### PR TITLE
Fix/dist build

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,6 +28,9 @@ jobs:
       - name: Install
         run: yarn install --frozen-lockfile --production
 
+      - name: Patch
+        run: yarn patch
+
       - name: Build
         env:
           NODE_ENV: production

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,6 +21,9 @@ jobs:
       - name: Install
         run: yarn install --immutable --immutable-cache --check-cache
 
+      - name: Patch
+        run: yarn patch
+
       - name: Test
         run: yarn test:ci
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile --production
 
+      - name: Patch
+        run: yarn patch
+
       - name: Build
         run: yarn build
 

--- a/components/Alert/Alert.stories.tsx
+++ b/components/Alert/Alert.stories.tsx
@@ -10,6 +10,7 @@ const AlertForStory = modifyVariantsForStory<AlertVariants, AlertProps>(BaseAler
 
 const Component: Meta<typeof AlertForStory> = {
   title: 'Components/Alert',
+  // @ts-expect-error
   component: Alert,
 };
 

--- a/components/Navigation/NavigationItem.stories.tsx
+++ b/components/Navigation/NavigationItem.stories.tsx
@@ -18,8 +18,10 @@ import { Badge } from '../Badge';
 
 const Component: Meta<typeof NavigationDrawer> = {
   title: 'Components/NavigationItem',
+  // @ts-expect-error
   component: NavigationItem,
   argTypes: {
+    // @ts-expect-error
     as: {
       options: ['a', 'button'],
     },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "deploy-storybook": "storybook-to-ghpages",
     "test": "jest --watch",
     "test:ci": "jest --ci --silent",
+    "patch": "patch-package",
     "prepare": "husky install",
     "pre-commit": "lint-staged"
   },
@@ -113,6 +114,7 @@
     "lint-staged": "13.1.0",
     "lodash.merge": "^4.6.2",
     "np": "^8.0.4",
+    "patch-package": "^8.0.0",
     "prettier": "^2.1.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/patches/@stitches+react+1.2.8.patch
+++ b/patches/@stitches+react+1.2.8.patch
@@ -1,0 +1,39 @@
+diff --git a/node_modules/@stitches/react/types/css-util.d.ts b/node_modules/@stitches/react/types/css-util.d.ts
+index 1668fc2ab56c421894c547b2e5a988166cd90e5f..cfdad3f208ef7f57c89de7fb94cdaecbd7378c63 100644
+--- a/node_modules/@stitches/react/types/css-util.d.ts
++++ b/node_modules/@stitches/react/types/css-util.d.ts
+@@ -117,3 +117,11 @@ export type $$ScaleValue = typeof $$ScaleValue
+ export declare const $$ThemeValue: unique symbol
+
+ export type $$ThemeValue = typeof $$ThemeValue
++
++// https://github.com/microsoft/TypeScript/issues/37888#issuecomment-846638356
++export type WithPropertyValue<T> = {
++	readonly [K in $$PropertyValue]: T
++}
++export type WithScaleValue<T> = {
++	readonly [K in $$ScaleValue]: T;
++}
+\ No newline at end of file
+diff --git a/node_modules/@stitches/react/types/index.d.ts b/node_modules/@stitches/react/types/index.d.ts
+index 8dbcc9cad3f6c556a3f370065dd95300a02dd973..dafadd22e8b6285aadee2630936a7918c9c5b02b 100644
+--- a/node_modules/@stitches/react/types/index.d.ts
++++ b/node_modules/@stitches/react/types/index.d.ts
+@@ -35,7 +35,7 @@ export type ComponentProps<Component> = Component extends ((...args: any[]) => a
+ /** Returns a type that expects a value to be a kind of CSS property value. */
+ export type PropertyValue<Property extends keyof CSSUtil.CSSProperties, Config = null> = (
+ 	Config extends null
+-		? { readonly [K in CSSUtil.$$PropertyValue]: Property }
++		? CSSUtil.WithPropertyValue<Property>
+ 	: Config extends { [K: string]: any }
+ 		? CSSUtil.CSS<
+ 			Config['media'],
+@@ -49,7 +49,7 @@ export type PropertyValue<Property extends keyof CSSUtil.CSSProperties, Config =
+ /** Returns a type that expects a value to be a kind of theme scale value. */
+ export type ScaleValue<Scale, Config = null> = (
+ 	Config extends null
+-		? { readonly [K in CSSUtil.$$ScaleValue]: Scale }
++		? CSSUtil.WithScaleValue<Scale>
+ 	: Config extends { [K: string]: any }
+ 		? Scale extends keyof Config['theme']
+ 			? `$${string & keyof Config['theme'][Scale]}`

--- a/stitches.config.ts
+++ b/stitches.config.ts
@@ -50,7 +50,7 @@ export const colors: Record<string, Property.Color> = {
   divider: 'hsl(207, 10%, 82%)',
 };
 
-const stitches = (createStitches as any)({
+const stitches = createStitches({
   theme: {
     colors: {
       ...colors,
@@ -270,6 +270,7 @@ export type CSS<T = typeof stitches.config> = StitchesCSS<T>;
 
 export const { styled, css, createTheme, getCssText, globalCss, keyframes, config } = stitches;
 
+// @ts-expect-error
 export const utils = config.utils;
 
 export const darkTheme = (primary: PrimaryColor) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3152,13 +3152,13 @@
     telejson "^7.2.0"
     tiny-invariant "^1.3.1"
 
-"@storybook/channels@8.1.3":
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-8.1.3.tgz#34afeecaf6278e7d11359182f5cf07f054f0ab85"
-  integrity sha512-iDoHFX3ty7vhSXegFRevJkQ6cV+QQ1JjDnoXK/SHeloMT26sn5gPtetn3ET9+6ZoFkU05Pf5d0DoywVOfumfcg==
+"@storybook/channels@8.1.4":
+  version "8.1.4"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-8.1.4.tgz#a77da3cfcb8a051cf882bb77e962bc79140e2f1a"
+  integrity sha512-cmITS0w8e9Ys1vqp8S7+uyQKgqVIdUEWs9FK90XeAs0lcuvW10S3qdrarWPbUgKFFFsGIGPIvImbT1vf80/bcQ==
   dependencies:
-    "@storybook/client-logger" "8.1.3"
-    "@storybook/core-events" "8.1.3"
+    "@storybook/client-logger" "8.1.4"
+    "@storybook/core-events" "8.1.4"
     "@storybook/global" "^5.0.0"
     telejson "^7.2.0"
     tiny-invariant "^1.3.1"
@@ -3231,10 +3231,10 @@
   dependencies:
     "@storybook/global" "^5.0.0"
 
-"@storybook/client-logger@8.1.3":
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-8.1.3.tgz#dcf6e7dc3d5757bcf2f7aa578a40aa9438c998f5"
-  integrity sha512-dX1jZ+HhJ8hVhAKHQ8gs/FalHjIGo5j1Xk+2UqdsGjLoBlwHIHfHzkVbzrc/gCxxXL0juisk7BzbXaz7lME0KA==
+"@storybook/client-logger@8.1.4":
+  version "8.1.4"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-8.1.4.tgz#e1c4bb9f933649918f30c261c2ad3a1fca594763"
+  integrity sha512-I0PqDoNZf4rqrJYwFHhCwuXumpxvzyTzI5qI5R2JT93i49QShI3pLXY31C9VemVBJmS+pBWVOm6RTIdkQiKVWw==
   dependencies:
     "@storybook/global" "^5.0.0"
 
@@ -3325,10 +3325,10 @@
   dependencies:
     ts-dedent "^2.0.0"
 
-"@storybook/core-events@8.1.3":
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-8.1.3.tgz#90e0292282cdb09acb15f1ee7054390bcc9209aa"
-  integrity sha512-eOs4HRrsEZz2FZFlMGwPuH9CGYBK8fkUS7mcHNPv8CqoHV8d3ErvDax8zA/KGRj3S6kWJ4PzI9IGuiDVvwuxhA==
+"@storybook/core-events@8.1.4":
+  version "8.1.4"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-8.1.4.tgz#043b1f210aa6b8da78b8cf9fc4763fb8ac198395"
+  integrity sha512-oZAP3aRDeRyo2GQmADh4R3wJLIb9Ie0FUcWx8V4fvuydzeh6Pprgo//COCR+kySG4kRLqofWeF1Zzvft58Q0kg==
   dependencies:
     "@storybook/csf" "^0.1.7"
     ts-dedent "^2.0.0"
@@ -3681,11 +3681,11 @@
     file-system-cache "2.3.0"
 
 "@storybook/types@^8.1.3":
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/@storybook/types/-/types-8.1.3.tgz#25c4e90dc342b76652fc96dd1aba7b44ea6dd2ab"
-  integrity sha512-2uUC1z7heMceRPHQ4KCcZwwKjtW2YiToUODsEw0YOq6NC/Q9elZta1FABSG0Bq7XM08EiAgjyc7P9CZPJ2QxUQ==
+  version "8.1.4"
+  resolved "https://registry.yarnpkg.com/@storybook/types/-/types-8.1.4.tgz#a50bfa21aa12212fb37b1185b6742d1ae70e474f"
+  integrity sha512-QfTJg5Hu3c0eiD38Z75bZsw0iCIpruOTGV5O65vCpNun7D6WUyyMM0aUJN3ytujGiHfjsWVgiSe+WoHxdy/fEA==
   dependencies:
-    "@storybook/channels" "8.1.3"
+    "@storybook/channels" "8.1.4"
     "@types/express" "^4.7.0"
     file-system-cache "2.3.0"
 
@@ -4255,6 +4255,11 @@
     "@types/emscripten" "^1.39.6"
     tslib "^1.13.0"
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 JSONStream@^1.0.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -4635,6 +4640,11 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
 available-typed-arrays@^1.0.7:
   version "1.0.7"
@@ -5069,9 +5079,9 @@ camelcase@^7.0.1:
   integrity sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==
 
 caniuse-lite@^1.0.30001587:
-  version "1.0.30001623"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001623.tgz#e982099dcb229bb6ab35f5aebe2f8d79ccf6e8a8"
-  integrity sha512-X/XhAVKlpIxWPpgRTnlgZssJrF0m6YtRA0QDWgsBNT12uZM6LPRydR7ip405Y3t1LamD8cP2TZFEDZFBf5ApcA==
+  version "1.0.30001624"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001624.tgz#0ec4c8fa7a46e5b785477c70b38a56d0b10058eb"
+  integrity sha512-0dWnQG87UevOCPYaOR49CBcLBwoZLpws+k6W37nLjWUhumP1Isusj0p2u+3KhjNloRWK9OKMgjBBzPujQHw4nA==
 
 cardinal@^2.1.1:
   version "2.1.1"
@@ -5190,7 +5200,7 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
-ci-info@^3.2.0:
+ci-info@^3.2.0, ci-info@^3.7.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
   integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
@@ -6810,6 +6820,13 @@ find-versions@^4.0.0:
   dependencies:
     semver-regex "^3.1.2"
 
+find-yarn-workspace-root@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
+  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
+  dependencies:
+    micromatch "^4.0.2"
+
 flow-parser@0.*:
   version "0.236.0"
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.236.0.tgz#8e8e6c59ff7e8d196c0ed215b3919320a1c6e332"
@@ -6904,6 +6921,16 @@ fs-extra@^11.0.0, fs-extra@^11.1.0:
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.2.0.tgz#e70e17dfad64232287d01929399e0ea7c86b0e5b"
   integrity sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==
   dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
+fs-extra@^9.0.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+  dependencies:
+    at-least-node "^1.0.0"
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
     universalify "^2.0.0"
@@ -8203,7 +8230,7 @@ is-weakset@^2.0.3:
     call-bind "^1.0.7"
     get-intrinsic "^1.2.4"
 
-is-wsl@^2.2.0:
+is-wsl@^2.1.1, is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
@@ -8947,6 +8974,16 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-stable-stringify@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.1.1.tgz#52d4361b47d49168bcc4e564189a42e5a7439454"
+  integrity sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg==
+  dependencies:
+    call-bind "^1.0.5"
+    isarray "^2.0.5"
+    jsonify "^0.0.1"
+    object-keys "^1.1.1"
+
 json-stringify-nice@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/json-stringify-nice/-/json-stringify-nice-1.1.4.tgz#2c937962b80181d3f317dd39aa323e14f5a60a67"
@@ -8970,6 +9007,11 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+jsonify@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.1.tgz#2aa3111dae3d34a0f151c63f3a45d995d9420978"
+  integrity sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==
 
 jsonparse@^1.2.0, jsonparse@^1.3.1:
   version "1.3.1"
@@ -8997,6 +9039,13 @@ kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
 
 kleur@^3.0.3:
   version "3.0.3"
@@ -10759,6 +10808,14 @@ onetime@^6.0.0:
   dependencies:
     mimic-fn "^4.0.0"
 
+open@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
+  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
+
 open@^8.0.4, open@^8.4.0:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/open/-/open-8.4.2.tgz#5b5ffe2a8f793dcd2aad73e550cb87b59cb084f9"
@@ -11101,6 +11158,27 @@ parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
+patch-package@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-8.0.0.tgz#d191e2f1b6e06a4624a0116bcb88edd6714ede61"
+  integrity sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^4.1.2"
+    ci-info "^3.7.0"
+    cross-spawn "^7.0.3"
+    find-yarn-workspace-root "^2.0.0"
+    fs-extra "^9.0.0"
+    json-stable-stringify "^1.0.2"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.6"
+    open "^7.4.2"
+    rimraf "^2.6.3"
+    semver "^7.5.3"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+    yaml "^2.2.2"
 
 path-exists@^3.0.0:
   version "3.0.0"
@@ -12006,7 +12084,7 @@ rfdc@^1.3.0:
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.1.tgz#2b6d4df52dffe8bb346992a10ea9451f24373a8f"
   integrity sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==
 
-rimraf@^2.6.1:
+rimraf@^2.6.1, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -12374,6 +12452,11 @@ sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slash@^3.0.0:
   version "3.0.0"
@@ -13927,7 +14010,7 @@ yaml@^1.10.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yaml@^2.1.3:
+yaml@^2.1.3, yaml@^2.2.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.4.2.tgz#7a2b30f2243a5fc299e1f14ca58d475ed4bc5362"
   integrity sha512-B3VqDZ+JAg1nZpaEmWtTXUlBneoGx6CPM9b0TENK6aoSu5t73dItudwdgmi6tHlIZZId4dZ9skcAQ2UbcyAeVA==


### PR DESCRIPTION
## Description

Stitches did not build components' types correctly after the previous update (https://github.com/traefik/faency/pull/431). This PR added a patch for stitches to avoid mistyping.