### PR TITLE
fix: explicit the date-fns dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "babel-loader": "^8.2.2",
     "conventional-changelog-conventionalcommits": "^4.6.3",
     "cross-env": "^7.0.3",
+    "date-fns": "^4.1.0",
     "husky": "^8.0.0",
     "lint-staged": "13.1.0",
     "lodash.merge": "^4.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6242,6 +6242,7 @@ __metadata:
     babel-loader: "npm:^8.2.2"
     conventional-changelog-conventionalcommits: "npm:^4.6.3"
     cross-env: "npm:^7.0.3"
+    date-fns: "npm:^4.1.0"
     eslint: "npm:9.x"
     eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-jsx-a11y: "npm:^6.9.0"
@@ -9141,6 +9142,13 @@ __metadata:
   version: 3.6.0
   resolution: "date-fns@npm:3.6.0"
   checksum: 10c0/0b5fb981590ef2f8e5a3ba6cd6d77faece0ea7f7158948f2eaae7bbb7c80a8f63ae30b01236c2923cf89bb3719c33aeb150c715ea4fe4e86e37dcf06bed42fb6
+  languageName: node
+  linkType: hard
+
+"date-fns@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "date-fns@npm:4.1.0"
+  checksum: 10c0/b79ff32830e6b7faa009590af6ae0fb8c3fd9ffad46d930548fbb5acf473773b4712ae887e156ba91a7b3dc30591ce0f517d69fd83bd9c38650fdc03b4e0bac8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This PR makes explicit the date-fns dependency.

## Preview

No visual changes.

## Dependency changes

| Dependency | Version        | State   |
| ---------- | -------------- | ------- |
| date-fns       | ^4.1.0          | Added   |


## Breaking changes

None.

## How to test?

```
nvm use && yarn && yarn storybook
```

## Good PR checkboxes

- [x] Change has been tested
- [ ] Added/Updated tests
- [ ] Added/Updated stories
- [x] PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
- [x] Labels are set
- [x] Project is linked

## Good Review checkboxes

<details>
<summary> ℹ️  Copy the snippet and paste in the review field to fill it</summary>

```markdown
- [ ] I've tested the changes
- [ ] I've agreed on the unit tests (soon to come)
- [ ] I've checked the stories
- [ ] I've read the code and understood it
- [ ] I don't have any more questions
- [ ] I've described any optional improvements
- [ ] I checked PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
```

</details>
