### PR TITLE
fix: aria-description in SidePanel

### DIFF
--- a/components/SidePanel/SidePanel.stories.tsx
+++ b/components/SidePanel/SidePanel.stories.tsx
@@ -67,7 +67,12 @@ export const Basic: StoryFn<typeof SidePanel> = (args) => {
         </Box>
       </Box>
 
-      <SidePanel {...args} open={open} onOpenChange={(isOpen) => setOpen(isOpen)}>
+      <SidePanel
+        {...args}
+        description="Lorem ipsum dolor sit amet"
+        open={open}
+        onOpenChange={(isOpen) => setOpen(isOpen)}
+      >
         <Content />
       </SidePanel>
     </>

--- a/components/SidePanel/SidePanel.tsx
+++ b/components/SidePanel/SidePanel.tsx
@@ -1,5 +1,6 @@
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { Cross1Icon } from '@radix-ui/react-icons';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import React, { ComponentProps } from 'react';
 
 import { CSS, keyframes, styled, VariantProps } from '../../stitches.config';
@@ -119,6 +120,7 @@ type SidePanelContentPrimitiveProps = React.ComponentProps<typeof DialogPrimitiv
 type SidePanelProps = SidePanelContentPrimitiveProps &
   SidePanelContentVariants & {
     css?: CSS;
+    description?: string;
     noOverlay?: boolean;
     noCloseIcon?: boolean;
     open?: boolean;
@@ -129,6 +131,7 @@ type SidePanelProps = SidePanelContentPrimitiveProps &
 export const SidePanel = React.forwardRef<React.ElementRef<typeof StyledContent>, SidePanelProps>(
   (
     {
+      description,
       noOverlay = false,
       noCloseIcon = false,
       children,
@@ -143,6 +146,11 @@ export const SidePanel = React.forwardRef<React.ElementRef<typeof StyledContent>
       <DialogPrimitive.Portal>
         {!noOverlay && <SidePanelOverlay />}
         <StyledContent {...props} ref={forwardedRef}>
+          {description ? (
+            <VisuallyHidden asChild>
+              <DialogPrimitive.Description>{description}</DialogPrimitive.Description>
+            </VisuallyHidden>
+          ) : null}
           {children}
           {!noCloseIcon && <SidePanelCloseIconButton />}
         </StyledContent>


### PR DESCRIPTION
## Description

This PR introduces an optional `description` property to the `SidePanel` component for accessibility purposes.

## Preview

No visual changes.

## Breaking changes

None.

## Good PR checkboxes

- [x] Change has been tested
- [ ] Added/Updated tests
- [x] Added/Updated stories
- [x] PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
- [x] Labels are set
- [x] Project is linked

## Good Review checkboxes

<details>
<summary> ℹ️  Copy the snippet and paste in the review field to fill it</summary>

```markdown
- [ ] I've tested the changes
- [ ] I've agreed on the unit tests (soon to come)
- [ ] I've checked the stories
- [ ] I've read the code and understood it
- [ ] I don't have any more questions
- [ ] I've described any optional improvements
- [ ] I checked PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
```

</details>
