### PR TITLE
fix: tooltip content type

### DIFF
--- a/components/Tooltip/Tooltip.stories.tsx
+++ b/components/Tooltip/Tooltip.stories.tsx
@@ -61,7 +61,6 @@ const HeadingOption = (
 );
 
 NodeContent.args = {
-  // @ts-ignore
   content: WarningOption,
 };
 
@@ -77,9 +76,8 @@ NodeContent.argTypes = {
 };
 
 export const Bubble: StoryFn<typeof TooltipForStory> = (args) => (
-  <TooltipForStory {...args} content="This is a green bubble">
+  <TooltipForStory {...args} content={<Text css={{ color: 'black' }}>This is a green bubble</Text>}>
     <BubbleComponent variant="green" size="large" />
   </TooltipForStory>
 );
-
 export default Component;

--- a/components/Tooltip/Tooltip.tsx
+++ b/components/Tooltip/Tooltip.tsx
@@ -6,7 +6,7 @@ import { Box } from '../Box';
 import { Text } from '../Text';
 
 export type TooltipProps = React.ComponentProps<typeof TooltipPrimitive.Root> &
-  React.ComponentProps<typeof TooltipPrimitive.Content> & {
+  Omit<React.ComponentProps<typeof TooltipPrimitive.Content>, 'content'> & {
     children: React.ReactElement | React.ReactNode;
     content: React.ReactElement | React.ReactNode;
     multiline?: boolean;
@@ -44,7 +44,7 @@ export const TooltipContent = React.forwardRef<
       side="top"
       align="center"
       sideOffset={5}
-      {...props}
+      {...(props as React.ComponentProps<typeof TooltipPrimitive.Content>)}
       multiline={multiline}
       ref={forwardedRef}
     >


### PR DESCRIPTION
## Description

Related to https://github.com/traefik/hub-issues/issues/1827
Follow up to https://github.com/traefik/faency/pull/5093

Fix content type for Tooltip to be able to receive ReactNode correctly.
