### PR TITLE
feat: enable custom names for dark and light themes

### DIFF
--- a/stitches.config.ts
+++ b/stitches.config.ts
@@ -273,10 +273,10 @@ export const { styled, css, createTheme, getCssText, globalCss, keyframes, confi
 // @ts-expect-error
 export const utils = config.utils;
 
-export const darkTheme = (primary: PrimaryColor) => {
+export const darkTheme = (primary: PrimaryColor, name = 'dark') => {
   const darkPrimaryColor = getPrimaryColorInfo(primary, darkColors);
 
-  return createTheme('dark', {
+  return createTheme(name, {
     colors: {
       ...darkColors,
 
@@ -312,10 +312,10 @@ export const darkTheme = (primary: PrimaryColor) => {
   });
 };
 
-export const lightTheme = (primary: PrimaryColor) => {
+export const lightTheme = (primary: PrimaryColor, name = 'light') => {
   const lightPrimaryColor = getPrimaryColorInfo(primary, lightColors);
 
-  return createTheme('light', {
+  return createTheme(name, {
     colors: {
       primary: lightPrimaryColor.token,
       ...AccordionTheme.getLight(lightPrimaryColor),


### PR DESCRIPTION
## Description

This PR allows specifying custom names for dark and light themes:

```js
const LIGHT_THEME = lightTheme("neon", "custom-light")
const DARK_THEME = darkTheme("neon", "custom-dark")
```

If no name is provided, the default names `dark` and `light` are used.

## Preview

No visual changes.

## Good PR checkboxes

- [x] Change has been tested
- [ ] Added/Updated tests
- [ ] Added/Updated stories
- [x] PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
- [x] Labels are set
- [x] Project is linked

## Good Review checkboxes

<details>
<summary> ℹ️  Copy the snippet and paste in the review field to fill it</summary>

```markdown
- [ ] I've tested the changes
- [ ] I've agreed on the unit tests (soon to come)
- [ ] I've checked the stories
- [ ] I've read the code and understood it
- [ ] I don't have any more questions
- [ ] I've described any optional improvements
- [ ] I checked PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
```

</details>
