### PR TITLE
fix: storybook initial theme for vanilla provider

### DIFF
--- a/.storybook/preview.jsx
+++ b/.storybook/preview.jsx
@@ -7,6 +7,8 @@ import { themes } from 'storybook/theming';
 import { globalCss } from '../';
 import { FaencyProvider } from '../components/FaencyProvider';
 import { darkTheme, lightTheme } from '../stitches.config';
+import { VanillaExtractThemeProvider } from '../styles/themeContext';
+import { themes as vanillaThemes } from '../styles/themes.css';
 
 const channel = addons.getChannel();
 
@@ -17,20 +19,41 @@ const channel = addons.getChannel();
 const getInitialThemePreference = () => {
   if (typeof window === 'undefined') return false;
 
-  // Check stored preference first
+  // Check stored preference
   const stored = localStorage.getItem('sb-addon-themes-3');
   if (stored) {
     try {
       const parsed = JSON.parse(stored);
-      if (parsed.current === 'dark') return true;
-    } catch (e) {
-      // Fall through to system preference
+      if (parsed.current) {
+        return parsed.current === 'dark';
+      }
+    } catch (error) {
+      console.warn('Failed to parse Storybook theme preference:', error);
     }
   }
 
-  // Fallback to system preference
+  // Fallback to system preference only if no stored value or parse error
   return window.matchMedia('(prefers-color-scheme: dark)').matches;
 };
+
+// Initialize vanilla-extract theme class immediately on script load
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  const initialTheme = getInitialThemePreference() ? 'dark' : 'light';
+  const themeClass = vanillaThemes[initialTheme]['blue'];
+
+  function applyInitialTheme() {
+    Object.values(vanillaThemes.light).forEach((cls) => document.body.classList.remove(cls));
+    Object.values(vanillaThemes.dark).forEach((cls) => document.body.classList.remove(cls));
+
+    document.body.classList.add(themeClass);
+  }
+
+  if (document.body) {
+    applyInitialTheme();
+  } else {
+    document.addEventListener('DOMContentLoaded', applyInitialTheme);
+  }
+}
 
 export const parameters = {
   controls: {
@@ -72,38 +95,14 @@ const globalStyle = globalCss({
 });
 
 const VanillaProviderWrapper = ({ children, isDark, primaryColor }) => {
-  const [Provider, setProvider] = React.useState(null);
-  const [loading, setLoading] = React.useState(true);
-
-  React.useEffect(() => {
-    import('../styles/themeContext')
-      .then((module) => {
-        setProvider(() => module.VanillaExtractThemeProvider);
-        setLoading(false);
-      })
-      .catch((err) => {
-        console.warn('VanillaExtractThemeProvider failed to load:', err);
-        setLoading(false);
-      });
-  }, []);
-
-  if (loading) {
-    return React.createElement('div', { style: { padding: '24px' } }, 'Loading theme system...');
-  }
-
-  if (Provider) {
-    return React.createElement(
-      Provider,
-      {
-        forcedTheme: isDark ? 'dark' : 'light',
-        primaryColor,
-      },
-      children,
-    );
-  }
-
-  // If provider failed to load, just return children (Stitches fallback)
-  return children;
+  return React.createElement(
+    VanillaExtractThemeProvider,
+    {
+      forcedTheme: isDark ? 'dark' : 'light',
+      primaryColor,
+    },
+    children,
+  );
 };
 
 export const decorators = [
@@ -119,6 +118,17 @@ export const decorators = [
       channel.on(DARK_MODE_EVENT_NAME, setDark);
       return () => channel.removeListener(DARK_MODE_EVENT_NAME, setDark);
     }, []);
+
+    // Apply vanilla-extract theme class before first render to prevent flash
+    React.useLayoutEffect(() => {
+      const resolvedTheme = isDark ? 'dark' : 'light';
+      const themeClass = vanillaThemes[resolvedTheme]['blue'];
+
+      Object.values(vanillaThemes.light).forEach((cls) => document.body.classList.remove(cls));
+      Object.values(vanillaThemes.dark).forEach((cls) => document.body.classList.remove(cls));
+
+      document.body.classList.add(themeClass);
+    }, [isDark]);
 
     return (
       <VanillaProviderWrapper isDark={isDark} primaryColor="blue">

--- a/stories/ThemeTest.stories.tsx
+++ b/stories/ThemeTest.stories.tsx
@@ -223,6 +223,3 @@ export const ThemeAPITest: StoryFn = () => {
 
   return <ThemeInfo />;
 };
-
-PrimaryColorShowcase.storyName = 'Primary Color Showcase';
-ThemeAPITest.storyName = 'Theme API Test';


### PR DESCRIPTION
## Description

On the initial load, vanilla extract provider always fallback to system theme if the forced theme is light.

This PR attempts a fix by setting the right condition check on the initial theme load, loading the theme class immediately to avoid flash, and to use `useLayoutEffect` to avoid repaint.

## How to test?

Check on any comparison stories, on the initial load the theme color for both components (stiches & vanilla) should be the same.

