### PR TITLE
fix: accept node as label on nav tree item

### DIFF
--- a/components/NavigationTree/NavigationTreeItem.stories.tsx
+++ b/components/NavigationTree/NavigationTreeItem.stories.tsx
@@ -13,7 +13,10 @@ import {
 import { Meta, StoryFn } from '@storybook/react-vite';
 import React, { useState } from 'react';
 
+import { Button } from '../Button';
+import { Flex } from '../Flex';
 import { NavigationDrawer } from '../Navigation';
+import { Text } from '../Text';
 import { NavigationTreeContainer } from './NavigationTreeContainer';
 import { NavigationTreeItem } from './NavigationTreeItem';
 
@@ -102,6 +105,31 @@ const Template: StoryFn<typeof NavigationTreeItem> = (args) => {
               {...navigationHandlerProps('one-one-one')}
               startAdornment={<ArchiveIcon />}
               label="One.One.One"
+            />
+          </NavigationTreeItem>
+        </NavigationTreeItem>
+
+        <NavigationTreeItem
+          {...navigationHandlerProps('two')}
+          label={
+            <Flex
+              gap={2}
+              align="center"
+              justify="space-between"
+              css={{ width: '100%', color: 'inherit' }}
+            >
+              <Text css={{ color: 'inherit' }}>Node label</Text>
+              <Button as="div" size="small">
+                Click
+              </Button>
+            </Flex>
+          }
+        >
+          <NavigationTreeItem {...navigationHandlerProps('two-one')} {...args}>
+            <NavigationTreeItem
+              {...navigationHandlerProps('two-one-one')}
+              startAdornment={<ArchiveIcon />}
+              label="Two.One.One"
             />
           </NavigationTreeItem>
         </NavigationTreeItem>

--- a/components/NavigationTree/NavigationTreeItem.tsx
+++ b/components/NavigationTree/NavigationTreeItem.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { ReactNode, useMemo, useState } from 'react';
 
 import { CSS } from '../..';
 import { Box } from '../Box';
@@ -8,7 +8,7 @@ import { Text } from '../Text';
 import { NavigationTreeContainer } from './NavigationTreeContainer';
 
 export interface NavigationTreeItemProps {
-  label: string;
+  label: string | ReactNode;
   subtitle?: string;
   children?: React.ReactNode;
   defaultExpanded?: boolean;
@@ -43,10 +43,10 @@ export const NavigationTreeItem = ({
       hasStartAdornment
         ? props.startAdornment
         : isExpandable
-        ? isExpanded
-          ? customCollapseIcon || defaultCollapseIcon
-          : customExpandIcon || defaultExpandIcon
-        : null,
+          ? isExpanded
+            ? customCollapseIcon || defaultCollapseIcon
+            : customExpandIcon || defaultExpandIcon
+          : null,
     [
       hasStartAdornment,
       isExpandable,
@@ -56,7 +56,7 @@ export const NavigationTreeItem = ({
       customCollapseIcon,
       customExpandIcon,
       props.startAdornment,
-    ]
+    ],
   );
 
   const childCss = useMemo(() => {
@@ -102,9 +102,13 @@ export const NavigationTreeItem = ({
           direction="column"
           align="start"
           gap={1}
-          css={{ ml: isExpandable || hasStartAdornment ? 0 : '$4', color: 'inherit' }}
+          css={{
+            ml: isExpandable || hasStartAdornment ? 0 : '$4',
+            color: 'inherit',
+            width: '100%',
+          }}
         >
-          <Text css={{ color: 'inherit' }}>{label}</Text>
+          {typeof label === 'string' ? <Text css={{ color: 'inherit' }}>{label}</Text> : label}
           {subtitle && (
             <Text variant="subtle" css={{ fontSize: '$3', opacity: 0.8 }}>
               {subtitle}


### PR DESCRIPTION
## Description

Fixes https://github.com/traefik/hub-issues/issues/2551

Add support for React nodes as navigation item labels. Remove unnecessary parent wrappers to allow more flexible styling of custom labels.

## Preview

<img width="176" height="113" alt="image" src="https://github.com/user-attachments/assets/4c935cd0-5135-4637-8df8-16a530877dc1" />

