### PR TITLE
ci: pin safe-chain to v1.4.7 and reduce minimum package age to 72h

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,7 +33,11 @@ jobs:
           cache: yarn
 
       - name: Setup safe-chain
-        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+        run: |
+          set -e
+          curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.4.7/install-safe-chain.sh -o /tmp/install-safe-chain.sh
+          echo "7934118ae7f81f69ac9e849c044b0c7009618b91859f06ec8b941258a43d98ed7d3712f9fde85304b7fcbbf723d2f0b5034e063342a675b38878e9cd2b587a04  /tmp/install-safe-chain.sh" | sha512sum -c -
+          sh /tmp/install-safe-chain.sh --ci
 
       - name: Config git
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ permissions:
   id-token: write
 
 env:
-  SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS: 360  # 15 days
+  SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS: 72  # 3 days
 
 jobs:
   faency:

--- a/.github/workflows/pr-prod-build.yaml
+++ b/.github/workflows/pr-prod-build.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 env:
-  SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS: 360  # 15 days
+  SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS: 72  # 3 days
 
 jobs:
   faency:

--- a/.github/workflows/pr-prod-build.yaml
+++ b/.github/workflows/pr-prod-build.yaml
@@ -24,7 +24,11 @@ jobs:
           cache: yarn
 
       - name: Setup safe-chain
-        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+        run: |
+          set -e
+          curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.4.7/install-safe-chain.sh -o /tmp/install-safe-chain.sh
+          echo "7934118ae7f81f69ac9e849c044b0c7009618b91859f06ec8b941258a43d98ed7d3712f9fde85304b7fcbbf723d2f0b5034e063342a675b38878e9cd2b587a04  /tmp/install-safe-chain.sh" | sha512sum -c -
+          sh /tmp/install-safe-chain.sh --ci
 
       - name: Install production dependencies
         run: yarn workspaces focus --all --production

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,7 +25,11 @@ jobs:
           cache: yarn
 
       - name: Setup safe-chain
-        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+        run: |
+          set -e
+          curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.4.7/install-safe-chain.sh -o /tmp/install-safe-chain.sh
+          echo "7934118ae7f81f69ac9e849c044b0c7009618b91859f06ec8b941258a43d98ed7d3712f9fde85304b7fcbbf723d2f0b5034e063342a675b38878e9cd2b587a04  /tmp/install-safe-chain.sh" | sha512sum -c -
+          sh /tmp/install-safe-chain.sh --ci
 
       - name: Install
         run: yarn install

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 env:
-  SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS: 360  # 15 days
+  SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS: 72  # 3 days
 
 jobs:
   faency:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
       - master
 
 env:
-  SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS: 360  # 15 days
+  SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS: 72  # 3 days
 
 permissions:
   contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,11 @@ jobs:
           cache: yarn
 
       - name: Setup safe-chain
-        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+        run: |
+          set -e
+          curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.4.7/install-safe-chain.sh -o /tmp/install-safe-chain.sh
+          echo "7934118ae7f81f69ac9e849c044b0c7009618b91859f06ec8b941258a43d98ed7d3712f9fde85304b7fcbbf723d2f0b5034e063342a675b38878e9cd2b587a04  /tmp/install-safe-chain.sh" | sha512sum -c -
+          sh /tmp/install-safe-chain.sh --ci
 
       - name: Install dependencies
         run: yarn workspaces focus --all --production

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,11 @@ Components follow a consistent pattern:
 - Run tests before submitting changes
 - Test coverage is currently being developed
 
+## Dependency Policy
+
+- **Pin all versions**: All dependencies must use exact pinned versions (no `^` or `~`). This applies to both `dependencies` and `devDependencies`.
+- **3-day rule**: When updating or adding dependencies, only use versions released more than 3 days ago. Check the npm release date before pinning a version.
+
 ## Important Notes
 
 - **Patch Required**: Run `yarn patch-package` after installing dependencies to fix Stitches TypeScript 5 compatibility


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Description

- **Pin safe-chain to v1.4.7** instead of always pulling `latest`, the install script is downloaded from a specific release and verified with a SHA-512 checksum before execution, preventing supply chain attacks via a compromised installer.
- **Reduce `SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS`** from 360 to 72 (3 days).

Fix https://github.com/traefik/hub-issues/issues/2782

## Good PR checkboxes

- [x] Change has been tested
- [ ] Added/Updated tests
- [ ] Added/Updated stories
- [x] PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
- [x] Labels are set
- [x] Project is linked

## Good Review checkboxes

<details>
<summary> ℹ️  Copy the snippet and paste in the review field to fill it</summary>

```markdown
- [ ] I've tested the changes
- [ ] I've agreed on the unit tests (soon to come)
- [ ] I've checked the stories
- [ ] I've read the code and understood it
- [ ] I don't have any more questions
- [ ] I've described any optional improvements
- [ ] I checked PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
```

</details>
