### PR TITLE
feat: add CodeBlock component and fix QA findings

### DIFF
--- a/.storybook/preview.jsx
+++ b/.storybook/preview.jsx
@@ -46,6 +46,8 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
     Object.values(vanillaThemes.dark).forEach((cls) => document.body.classList.remove(cls));
 
     document.body.classList.add(themeClass);
+    document.documentElement.classList.toggle('dark', initialTheme === 'dark');
+    document.documentElement.classList.toggle('light', initialTheme === 'light');
   }
 
   if (document.body) {
@@ -128,6 +130,8 @@ export const decorators = [
       Object.values(vanillaThemes.dark).forEach((cls) => document.body.classList.remove(cls));
 
       document.body.classList.add(themeClass);
+      document.documentElement.classList.toggle('dark', isDark);
+      document.documentElement.classList.toggle('light', !isDark);
     }, [isDark]);
 
     return (

--- a/VANILLA_EXTRACT_DEVELOPER_GUIDE.md
+++ b/VANILLA_EXTRACT_DEVELOPER_GUIDE.md
@@ -526,6 +526,43 @@ globalStyle(`${skeleton}:not(:empty) > *`, { visibility: 'hidden' });
 
 **Note:** `CSSProps` accepts both abbreviated (`p`, `m`) and full names (`padding`, `margin`).
 
+#### `act()` warning with async event handlers
+
+`Warning: The current testing environment is not configured to support act(...)` fires in React 18 when `setState` is called after an `await` inside an event handler and that microtask resolves _outside_ an active `act()`.
+
+**Why it's tricky:** RTL's `act` sets `IS_REACT_ACT_ENVIRONMENT = true` for its duration, then **restores** the previous value (usually `undefined`). If an async handler like `await clipboard.writeText()` → `setState()` resolves after the act exits, `IS_REACT_ACT_ENVIRONMENT` is already `false` and React warns.
+
+**Also:** `yarn test:ci` runs with `--silent` which hides `console.error` — always use `yarn test` to see real warnings.
+
+**For regular click-then-assert tests** — use `waitFor` after the click. RTL's `waitFor` unsets `IS_REACT_ACT_ENVIRONMENT` during polling, which suppresses the warning:
+
+```ts
+await userEvent.click(button);
+await waitFor(() => expect(button).toHaveTextContent('Copied!'));
+```
+
+**For fake-timer tests** (e.g. testing a timed state revert) — use `fireEvent.click` (synchronous) instead of `userEvent.click`, then drain the microtask queue with `await Promise.resolve()` inside `act`. Because `fireEvent` is synchronous, the clipboard Promise hasn't run yet when we hit the `await`, so it resolves _inside_ the act while `IS_REACT_ACT_ENVIRONMENT` is still `true`:
+
+```ts
+jest.useFakeTimers('legacy'); // NOT 'modern' — modern also fakes queueMicrotask which React 18 needs
+
+await act(async () => {
+  fireEvent.click(button);
+  await Promise.resolve(); // drains clipboard Promise microtask inside act
+});
+expect(button).toHaveTextContent('Copied!');
+
+act(() => jest.advanceTimersByTime(1500));
+expect(button).toHaveTextContent('Copy');
+```
+
+Always add `afterEach(() => jest.useRealTimers())` so fake timers don't leak — `axe` uses `setTimeout` internally and will hang if timers are still faked from a previous test.
+
+**What does NOT work:**
+
+- Setting `global.IS_REACT_ACT_ENVIRONMENT = true` in `jest.setup.js` — RTL restores the flag after each act regardless
+- `await act(async () => { await userEvent.click(button); await Promise.resolve() })` — `userEvent`'s internal async steps already process microtasks between events, so the Promise fires during the click, outside the window where the extra `Promise.resolve()` can help
+
 ### Build or Storybook Issues
 
 - **Build errors**: Check [vite.config.ts](vite.config.ts) has `vanillaExtractPlugin()`

--- a/components/AriaTable/AriaTable.tsx
+++ b/components/AriaTable/AriaTable.tsx
@@ -13,7 +13,7 @@ import React, {
   useState,
 } from 'react';
 
-import { styled, VariantProps } from '../../stitches.config';
+import { CSS, styled, VariantProps } from '../../stitches.config';
 import { Box } from '../Box';
 import type { TableVariants } from '../Table';
 import {
@@ -280,4 +280,4 @@ export const Table = forwardRef<
 ));
 
 export type AriaTableVariants = VariantProps<typeof Table>;
-export type AriaTableProps = TableVariants & NonNullable<unknown>;
+export type AriaTableProps = TableVariants & { children?: React.ReactNode; css?: CSS };

--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -239,6 +239,7 @@ export const StyledButton = styled('button', BUTTON_BASE_STYLES, {
       css: {
         backgroundColor: 'transparent',
         color: '$buttonSecondaryText',
+        boxShadow: 'none',
       },
     },
     {

--- a/components/CodeBlock/CodeBlock.stories.tsx
+++ b/components/CodeBlock/CodeBlock.stories.tsx
@@ -1,0 +1,201 @@
+// @ts-expect-error - cannot use "moduleResolution": "bundler" yet.
+import { Meta, StoryFn } from '@storybook/react-vite';
+import React from 'react';
+
+import { BoxVanilla } from '../Box/Box.vanilla';
+import { FlexVanilla } from '../Flex/Flex.vanilla';
+import { H3Vanilla } from '../Heading';
+import { CodeBlock } from './CodeBlock';
+import { CodeBlockVanilla } from './CodeBlock.vanilla';
+
+const Component: Meta<typeof CodeBlockVanilla> = {
+  title: 'Components/CodeBlock',
+  component: CodeBlockVanilla,
+  args: {
+    lang: 'typescript',
+    code: `import { CodeBlockVanilla } from '@traefik-labs/faency';
+
+const Example = () => (
+  <CodeBlockVanilla lang="typescript" code={snippet} copyable />
+);`,
+  },
+};
+
+export const Basic: StoryFn<typeof CodeBlockVanilla> = (args) => <CodeBlockVanilla {...args} />;
+
+export const Copyable: StoryFn<typeof CodeBlockVanilla> = (args) => (
+  <CodeBlockVanilla {...args} copyable />
+);
+
+export const NoBorder: StoryFn<typeof CodeBlockVanilla> = (args) => (
+  <CodeBlockVanilla {...args} noBorder />
+);
+
+export const WrapText: StoryFn<typeof CodeBlockVanilla> = (args) => (
+  <CodeBlockVanilla
+    {...args}
+    wrapText
+    lang="bash"
+    code="npm install --save-dev @traefik-labs/faency @stitches/react @radix-ui/react-icons @radix-ui/react-tooltip react react-dom"
+  />
+);
+
+export const JavaScript: StoryFn<typeof CodeBlockVanilla> = (args) => (
+  <CodeBlockVanilla
+    {...args}
+    lang="javascript"
+    code={`const greet = (name) => {
+  console.log(\`Hello, \${name}!\`);
+};
+
+greet('World');`}
+    copyable
+  />
+);
+
+export const JSON: StoryFn<typeof CodeBlockVanilla> = (args) => (
+  <CodeBlockVanilla
+    {...args}
+    lang="json"
+    code={`{
+  "name": "@traefik-labs/faency",
+  "version": "1.0.0",
+  "dependencies": {
+    "react": ">=18",
+    "prism-react-renderer": "2.4.1"
+  }
+}`}
+    copyable
+  />
+);
+
+export const YAML: StoryFn<typeof CodeBlockVanilla> = (args) => (
+  <CodeBlockVanilla
+    {...args}
+    lang="yaml"
+    code={`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: my-app`}
+    copyable
+  />
+);
+
+const COMPARISON_CODE = `const greet = (name: string) => {
+  console.log(\`Hello, \${name}!\`);
+};`;
+
+export const Comparison: StoryFn = () => (
+  <FlexVanilla direction="column" gap={6}>
+    <BoxVanilla>
+      <H3Vanilla css={{ marginBottom: '16px' }}>Stitches Version</H3Vanilla>
+      <CodeBlock lang="typescript" code={COMPARISON_CODE} copyable />
+    </BoxVanilla>
+    <BoxVanilla>
+      <H3Vanilla css={{ marginBottom: '16px' }}>Vanilla Extract Version</H3Vanilla>
+      <CodeBlockVanilla lang="typescript" code={COMPARISON_CODE} copyable />
+    </BoxVanilla>
+  </FlexVanilla>
+);
+
+export const Scrollable: StoryFn<typeof CodeBlockVanilla> = (args) => (
+  <CodeBlockVanilla
+    {...args}
+    copyable
+    copyText="Copy"
+    copiedText="Copied!"
+    lang="typescript"
+    code={`import React, { useState, useEffect, useCallback, useRef } from 'react';
+
+interface UseFetchOptions<T> {
+  initialData?: T;
+  onSuccess?: (data: T) => void;
+  onError?: (error: Error) => void;
+  enabled?: boolean;
+}
+
+interface UseFetchResult<T> {
+  data: T | undefined;
+  error: Error | undefined;
+  loading: boolean;
+  refetch: () => void;
+}
+
+export function useFetch<T>(url: string, options: UseFetchOptions<T> = {}): UseFetchResult<T> {
+  const { initialData, onSuccess, onError, enabled = true } = options;
+
+  const [data, setData] = useState<T | undefined>(initialData);
+  const [error, setError] = useState<Error | undefined>(undefined);
+  const [loading, setLoading] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const fetchData = useCallback(async () => {
+    if (!enabled) return;
+
+    abortRef.current?.abort();
+    abortRef.current = new AbortController();
+
+    setLoading(true);
+    setError(undefined);
+
+    try {
+      const response = await fetch(url, { signal: abortRef.current.signal });
+
+      if (!response.ok) {
+        throw new Error(\`HTTP error: \${response.status} \${response.statusText}\`);
+      }
+
+      const json: T = await response.json();
+      setData(json);
+      onSuccess?.(json);
+    } catch (err) {
+      if ((err as Error).name !== 'AbortError') {
+        const error = err instanceof Error ? err : new Error(String(err));
+        setError(error);
+        onError?.(error);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [url, enabled, onSuccess, onError]);
+
+  useEffect(() => {
+    fetchData();
+    return () => abortRef.current?.abort();
+  }, [fetchData]);
+
+  return { data, error, loading, refetch: fetchData };
+}
+
+// Usage example
+const UserProfile = ({ userId }: { userId: string }) => {
+  const { data, error, loading, refetch } = useFetch<{ name: string; email: string }>(
+    \`/api/users/\${userId}\`,
+    {
+      onSuccess: (user) => console.log('Loaded user:', user.name),
+      onError: (err) => console.error('Failed to load user:', err.message),
+    },
+  );
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message} <button onClick={refetch}>Retry</button></div>;
+  if (!data) return null;
+
+  return (
+    <div>
+      <h1>{data.name}</h1>
+      <p>{data.email}</p>
+    </div>
+  );
+};
+
+export default UserProfile;`}
+  />
+);
+
+export default Component;

--- a/components/CodeBlock/CodeBlock.stories.tsx
+++ b/components/CodeBlock/CodeBlock.stories.tsx
@@ -3,6 +3,7 @@ import { Meta, StoryFn } from '@storybook/react-vite';
 import React from 'react';
 
 import { BoxVanilla } from '../Box/Box.vanilla';
+import { CardVanilla } from '../Card/Card.vanilla';
 import { FlexVanilla } from '../Flex/Flex.vanilla';
 import { H3Vanilla } from '../Heading';
 import { CodeBlock } from './CodeBlock';
@@ -103,14 +104,25 @@ export const Comparison: StoryFn = () => (
   </FlexVanilla>
 );
 
+export const InCard: StoryFn<typeof CodeBlockVanilla> = (args) => (
+  <CardVanilla css={{ padding: 0 }}>
+    <CodeBlockVanilla {...args} copyable noBorder />
+  </CardVanilla>
+);
+
+export const CopyButtonAlignBottom: StoryFn<typeof CodeBlockVanilla> = (args) => (
+  <CodeBlockVanilla {...args} copyable copyButtonAlign="bottom" />
+);
+
 export const Scrollable: StoryFn<typeof CodeBlockVanilla> = (args) => (
-  <CodeBlockVanilla
-    {...args}
-    copyable
-    copyText="Copy"
-    copiedText="Copied!"
-    lang="typescript"
-    code={`import React, { useState, useEffect, useCallback, useRef } from 'react';
+  <CodeBlockVanilla {...args} />
+);
+Scrollable.args = {
+  copyable: true,
+  copyText: 'Copy',
+  copiedText: 'Copied!',
+  lang: 'typescript',
+  code: `import React, { useState, useEffect, useCallback, useRef } from 'react';
 
 interface UseFetchOptions<T> {
   initialData?: T;
@@ -194,8 +206,7 @@ const UserProfile = ({ userId }: { userId: string }) => {
   );
 };
 
-export default UserProfile;`}
-  />
-);
+export default UserProfile;`,
+};
 
 export default Component;

--- a/components/CodeBlock/CodeBlock.tsx
+++ b/components/CodeBlock/CodeBlock.tsx
@@ -1,6 +1,6 @@
 import { CheckIcon, CopyIcon } from '@radix-ui/react-icons';
 import { Highlight, Language, themes } from 'prism-react-renderer';
-import React, { ComponentProps, useState } from 'react';
+import React, { ComponentProps, forwardRef, useState } from 'react';
 
 import { CSS, styled } from '../../stitches.config';
 import { AccessibleIcon } from '../AccessibleIcon';
@@ -11,7 +11,6 @@ import { useColorScheme } from '../FaencyProvider';
 const Pre = styled('pre', {
   m: 0,
   borderRadius: '$2',
-  maxHeight: 424,
   overflow: 'auto',
   border: '1px solid $colors$deepBlue3',
   position: 'relative',
@@ -41,71 +40,91 @@ export type CodeBlockProps = {
   noBorder?: boolean;
   wrapText?: boolean;
   colorScheme?: 'light' | 'dark';
+  maxHeight?: number | string;
   css?: CSS;
 } & Omit<ComponentProps<typeof Pre>, 'css'>;
 
-export const CodeBlock = ({
-  lang,
-  code,
-  copyable = false,
-  copyText,
-  copiedText,
-  noBorder,
-  wrapText = false,
-  colorScheme,
-  css,
-  ...props
-}: CodeBlockProps) => {
-  const systemScheme = useColorScheme();
-  const resolvedScheme = colorScheme ?? systemScheme;
-  const prismTheme = resolvedScheme === 'dark' ? themes.nightOwl : themes.nightOwlLight;
+export const CodeBlock = forwardRef<HTMLPreElement, CodeBlockProps>(
+  (
+    {
+      lang,
+      code,
+      copyable = false,
+      copyText,
+      copiedText,
+      noBorder,
+      wrapText = false,
+      colorScheme,
+      maxHeight = 424,
+      css,
+      ...props
+    },
+    ref,
+  ) => {
+    const systemScheme = useColorScheme();
+    const resolvedScheme = colorScheme ?? systemScheme;
+    const prismTheme = resolvedScheme === 'dark' ? themes.nightOwl : themes.nightOwlLight;
 
-  const [copied, setCopied] = useState(false);
+    const [copied, setCopied] = useState(false);
 
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(code);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
-  };
+    const handleCopy = async () => {
+      try {
+        await navigator.clipboard.writeText(code);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      } catch {
+        // clipboard write failed (e.g. permission denied) — leave UI unchanged
+      }
+    };
 
-  return (
-    <Highlight theme={prismTheme} code={code} language={lang}>
-      {({ className, style, tokens, getLineProps, getTokenProps }) => (
-        <Box css={{ position: 'relative', ...css }}>
-          {copyable && (
-            <CopyButtonWrapper>
-              <Button
-                variant="secondary"
-                ghost
-                size="small"
-                type="button"
-                onClick={handleCopy}
-                css={{ color: '$hiContrast', gap: '$1' }}
-              >
-                <AccessibleIcon label={copied ? 'Copied' : 'Copy'}>
-                  {copied ? <CheckIcon /> : <CopyIcon />}
-                </AccessibleIcon>
-                {copied ? copiedText : copyText}
-              </Button>
-            </CopyButtonWrapper>
-          )}
-          <Pre className={className} style={style} noBorder={noBorder} {...props}>
-            <Box css={{ p: '$4' }}>
-              {tokens.map((line, i) => (
-                <div
-                  key={i}
-                  {...getLineProps({ line })}
-                  style={wrapText ? { whiteSpace: 'normal' } : undefined}
+    return (
+      <Highlight theme={prismTheme} code={code} language={lang}>
+        {({ className, style, tokens, getLineProps, getTokenProps }) => (
+          <Box css={{ position: 'relative', ...css }}>
+            {copyable && (
+              <CopyButtonWrapper>
+                <Button
+                  variant="secondary"
+                  ghost
+                  size="small"
+                  type="button"
+                  onClick={handleCopy}
+                  css={{ color: '$hiContrast', gap: '$1' }}
                 >
-                  {line.map((token, key) => (
-                    <span key={key} {...getTokenProps({ token })} />
-                  ))}
-                </div>
-              ))}
-            </Box>
-          </Pre>
-        </Box>
-      )}
-    </Highlight>
-  );
-};
+                  <AccessibleIcon label={copied ? 'Copied' : 'Copy'}>
+                    {copied ? <CheckIcon /> : <CopyIcon />}
+                  </AccessibleIcon>
+                  {copied ? copiedText : copyText}
+                </Button>
+              </CopyButtonWrapper>
+            )}
+            <Pre
+              ref={ref}
+              className={className}
+              style={style}
+              noBorder={noBorder}
+              css={{ maxHeight }}
+              {...props}
+            >
+              <Box css={{ p: '$4' }}>
+                {tokens.map((line, i) => (
+                  <div
+                    key={i}
+                    {...getLineProps({ line })}
+                    style={wrapText ? { whiteSpace: 'normal' } : undefined}
+                  >
+                    {line.map((token, key) => (
+                      <span key={key} {...getTokenProps({ token })} />
+                    ))}
+                  </div>
+                ))}
+              </Box>
+            </Pre>
+          </Box>
+        )}
+      </Highlight>
+    );
+  },
+);
+
+CodeBlock.displayName = 'CodeBlock';

--- a/components/CodeBlock/CodeBlock.tsx
+++ b/components/CodeBlock/CodeBlock.tsx
@@ -26,9 +26,19 @@ const Pre = styled('pre', {
 
 const CopyButtonWrapper = styled('div', {
   position: 'absolute',
-  top: '$2',
   right: '$4',
   zIndex: 1,
+
+  variants: {
+    align: {
+      top: { top: '$2' },
+      bottom: { bottom: '$2' },
+    },
+  },
+
+  defaultVariants: {
+    align: 'top',
+  },
 });
 
 export type CodeBlockProps = {
@@ -37,6 +47,7 @@ export type CodeBlockProps = {
   copyable?: boolean;
   copyText?: string;
   copiedText?: string;
+  copyButtonAlign?: 'top' | 'bottom';
   noBorder?: boolean;
   wrapText?: boolean;
   colorScheme?: 'light' | 'dark';
@@ -52,6 +63,7 @@ export const CodeBlock = forwardRef<HTMLPreElement, CodeBlockProps>(
       copyable = false,
       copyText,
       copiedText,
+      copyButtonAlign = 'top',
       noBorder,
       wrapText = false,
       colorScheme,
@@ -82,7 +94,7 @@ export const CodeBlock = forwardRef<HTMLPreElement, CodeBlockProps>(
         {({ className, style, tokens, getLineProps, getTokenProps }) => (
           <Box css={{ position: 'relative', ...css }}>
             {copyable && (
-              <CopyButtonWrapper>
+              <CopyButtonWrapper align={copyButtonAlign}>
                 <Button
                   variant="secondary"
                   ghost
@@ -101,7 +113,7 @@ export const CodeBlock = forwardRef<HTMLPreElement, CodeBlockProps>(
             <Pre
               ref={ref}
               className={className}
-              style={style}
+              style={{ ...style, backgroundColor: 'transparent' }}
               noBorder={noBorder}
               css={{ maxHeight }}
               {...props}

--- a/components/CodeBlock/CodeBlock.tsx
+++ b/components/CodeBlock/CodeBlock.tsx
@@ -1,0 +1,111 @@
+import { CheckIcon, CopyIcon } from '@radix-ui/react-icons';
+import { Highlight, Language, themes } from 'prism-react-renderer';
+import React, { ComponentProps, useState } from 'react';
+
+import { CSS, styled } from '../../stitches.config';
+import { AccessibleIcon } from '../AccessibleIcon';
+import { Box } from '../Box';
+import { Button } from '../Button';
+import { useColorScheme } from '../FaencyProvider';
+
+const Pre = styled('pre', {
+  m: 0,
+  borderRadius: '$2',
+  maxHeight: 424,
+  overflow: 'auto',
+  border: '1px solid $colors$deepBlue3',
+  position: 'relative',
+  fontSize: '$2',
+  lineHeight: 1.6,
+
+  variants: {
+    noBorder: {
+      true: { border: 'none' },
+    },
+  },
+});
+
+const CopyButtonWrapper = styled('div', {
+  position: 'absolute',
+  top: '$2',
+  right: '$4',
+  zIndex: 1,
+});
+
+export type CodeBlockProps = {
+  lang: Language;
+  code: string;
+  copyable?: boolean;
+  copyText?: string;
+  copiedText?: string;
+  noBorder?: boolean;
+  wrapText?: boolean;
+  colorScheme?: 'light' | 'dark';
+  css?: CSS;
+} & Omit<ComponentProps<typeof Pre>, 'css'>;
+
+export const CodeBlock = ({
+  lang,
+  code,
+  copyable = false,
+  copyText,
+  copiedText,
+  noBorder,
+  wrapText = false,
+  colorScheme,
+  css,
+  ...props
+}: CodeBlockProps) => {
+  const systemScheme = useColorScheme();
+  const resolvedScheme = colorScheme ?? systemScheme;
+  const prismTheme = resolvedScheme === 'dark' ? themes.nightOwl : themes.nightOwlLight;
+
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <Highlight theme={prismTheme} code={code} language={lang}>
+      {({ className, style, tokens, getLineProps, getTokenProps }) => (
+        <Box css={{ position: 'relative', ...css }}>
+          {copyable && (
+            <CopyButtonWrapper>
+              <Button
+                variant="secondary"
+                ghost
+                size="small"
+                type="button"
+                onClick={handleCopy}
+                css={{ color: '$hiContrast', gap: '$1' }}
+              >
+                <AccessibleIcon label={copied ? 'Copied' : 'Copy'}>
+                  {copied ? <CheckIcon /> : <CopyIcon />}
+                </AccessibleIcon>
+                {copied ? copiedText : copyText}
+              </Button>
+            </CopyButtonWrapper>
+          )}
+          <Pre className={className} style={style} noBorder={noBorder} {...props}>
+            <Box css={{ p: '$4' }}>
+              {tokens.map((line, i) => (
+                <div
+                  key={i}
+                  {...getLineProps({ line })}
+                  style={wrapText ? { whiteSpace: 'normal' } : undefined}
+                >
+                  {line.map((token, key) => (
+                    <span key={key} {...getTokenProps({ token })} />
+                  ))}
+                </div>
+              ))}
+            </Box>
+          </Pre>
+        </Box>
+      )}
+    </Highlight>
+  );
+};

--- a/components/CodeBlock/CodeBlock.tsx
+++ b/components/CodeBlock/CodeBlock.tsx
@@ -6,7 +6,7 @@ import { CSS, styled } from '../../stitches.config';
 import { AccessibleIcon } from '../AccessibleIcon';
 import { Box } from '../Box';
 import { Button } from '../Button';
-import { useColorScheme } from '../FaencyProvider';
+import { useColorScheme } from '../colorSchemeContext';
 
 const Pre = styled('pre', {
   m: 0,

--- a/components/CodeBlock/CodeBlock.vanilla.css.ts
+++ b/components/CodeBlock/CodeBlock.vanilla.css.ts
@@ -9,7 +9,6 @@ export const wrapper = style({
 export const pre = style({
   margin: 0,
   borderRadius: tokens.radii['2'],
-  maxHeight: 424,
   overflow: 'auto',
   border: `1px solid ${tokens.colors.deepBlue['3']}`,
   position: 'relative',

--- a/components/CodeBlock/CodeBlock.vanilla.css.ts
+++ b/components/CodeBlock/CodeBlock.vanilla.css.ts
@@ -26,7 +26,14 @@ export const codeContent = style({
 
 export const copyButtonWrapper = style({
   position: 'absolute',
-  top: tokens.space['2'],
   right: tokens.space['4'],
   zIndex: 1,
+});
+
+export const copyButtonWrapperTop = style({
+  top: tokens.space['2'],
+});
+
+export const copyButtonWrapperBottom = style({
+  bottom: tokens.space['2'],
 });

--- a/components/CodeBlock/CodeBlock.vanilla.css.ts
+++ b/components/CodeBlock/CodeBlock.vanilla.css.ts
@@ -1,0 +1,33 @@
+import { style } from '@vanilla-extract/css';
+
+import { tokens } from '../../styles/tokens.css';
+
+export const wrapper = style({
+  position: 'relative',
+});
+
+export const pre = style({
+  margin: 0,
+  borderRadius: tokens.radii['2'],
+  maxHeight: 424,
+  overflow: 'auto',
+  border: `1px solid ${tokens.colors.deepBlue['3']}`,
+  position: 'relative',
+  fontSize: tokens.fontSizes['2'],
+  lineHeight: '1.6',
+});
+
+export const preNoBorder = style({
+  border: 'none',
+});
+
+export const codeContent = style({
+  padding: tokens.space['4'],
+});
+
+export const copyButtonWrapper = style({
+  position: 'absolute',
+  top: tokens.space['2'],
+  right: tokens.space['4'],
+  zIndex: 1,
+});

--- a/components/CodeBlock/CodeBlock.vanilla.test.tsx
+++ b/components/CodeBlock/CodeBlock.vanilla.test.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 import { VanillaExtractThemeProvider } from '../../styles/themeContext';
 import { CodeBlockVanilla } from './CodeBlock.vanilla';
+import { preNoBorder } from './CodeBlock.vanilla.css';
 
 const CODE_SNIPPET = `const greet = (name: string) => {
   console.log(\`Hello, \${name}!\`);
@@ -133,18 +134,40 @@ describe('CodeBlockVanilla', () => {
     expect(button).toHaveTextContent('Copy');
   });
 
-  it('should render without border when noBorder is true', () => {
+  it('should apply noBorder class when noBorder is true', () => {
     const { container } = renderWithTheme(
       <CodeBlockVanilla lang="typescript" code={CODE_SNIPPET} noBorder />,
     );
-    expect(container.querySelector('pre')).toBeInTheDocument();
+    expect(container.querySelector('pre')?.className).toContain(preNoBorder);
   });
 
-  it('should apply wrapText prop', () => {
+  it('should not apply noBorder class when noBorder is false', () => {
+    const { container } = renderWithTheme(
+      <CodeBlockVanilla lang="typescript" code={CODE_SNIPPET} />,
+    );
+    expect(container.querySelector('pre')?.className).not.toContain(preNoBorder);
+  });
+
+  it('should apply whiteSpace: normal to lines when wrapText is true', () => {
     const { container } = renderWithTheme(
       <CodeBlockVanilla lang="typescript" code={CODE_SNIPPET} wrapText />,
     );
-    expect(container.querySelector('pre')).toBeInTheDocument();
+    const lineDivs = container.querySelectorAll('pre > div > div');
+    expect(lineDivs.length).toBeGreaterThan(0);
+    lineDivs.forEach((div) => {
+      expect((div as HTMLElement).style.whiteSpace).toBe('normal');
+    });
+  });
+
+  it('should not apply whiteSpace: normal to lines when wrapText is false', () => {
+    const { container } = renderWithTheme(
+      <CodeBlockVanilla lang="typescript" code={CODE_SNIPPET} />,
+    );
+    const lineDivs = container.querySelectorAll('pre > div > div');
+    expect(lineDivs.length).toBeGreaterThan(0);
+    lineDivs.forEach((div) => {
+      expect((div as HTMLElement).style.whiteSpace).toBe('');
+    });
   });
 
   it('should render different languages', () => {
@@ -195,21 +218,35 @@ describe('CodeBlockVanilla', () => {
     expect(results).toHaveNoViolations();
   }, 10000);
 
-  it('should work with light theme', () => {
-    const { container } = render(
+  it('should apply different prism theme styles for light and dark', () => {
+    const { container: lightContainer } = render(
       <VanillaExtractThemeProvider defaultTheme="light">
         <CodeBlockVanilla lang="typescript" code={CODE_SNIPPET} />
       </VanillaExtractThemeProvider>,
     );
-    expect(container.querySelector('pre')).toBeInTheDocument();
-  });
-
-  it('should work with dark theme', () => {
-    const { container } = render(
+    const { container: darkContainer } = render(
       <VanillaExtractThemeProvider defaultTheme="dark">
         <CodeBlockVanilla lang="typescript" code={CODE_SNIPPET} />
       </VanillaExtractThemeProvider>,
     );
-    expect(container.querySelector('pre')).toBeInTheDocument();
+    const lightStyle = lightContainer.querySelector('pre')?.getAttribute('style');
+    const darkStyle = darkContainer.querySelector('pre')?.getAttribute('style');
+    expect(lightStyle).not.toBe(darkStyle);
+  });
+
+  it('should respect colorScheme prop override regardless of context theme', () => {
+    const { container: forcedLight } = render(
+      <VanillaExtractThemeProvider defaultTheme="dark">
+        <CodeBlockVanilla lang="typescript" code={CODE_SNIPPET} colorScheme="light" />
+      </VanillaExtractThemeProvider>,
+    );
+    const { container: contextLight } = render(
+      <VanillaExtractThemeProvider defaultTheme="light">
+        <CodeBlockVanilla lang="typescript" code={CODE_SNIPPET} />
+      </VanillaExtractThemeProvider>,
+    );
+    const forcedStyle = forcedLight.querySelector('pre')?.getAttribute('style');
+    const contextStyle = contextLight.querySelector('pre')?.getAttribute('style');
+    expect(forcedStyle).toBe(contextStyle);
   });
 });

--- a/components/CodeBlock/CodeBlock.vanilla.test.tsx
+++ b/components/CodeBlock/CodeBlock.vanilla.test.tsx
@@ -1,0 +1,215 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import React from 'react';
+
+import { VanillaExtractThemeProvider } from '../../styles/themeContext';
+import { CodeBlockVanilla } from './CodeBlock.vanilla';
+
+const CODE_SNIPPET = `const greet = (name: string) => {
+  console.log(\`Hello, \${name}!\`);
+};`;
+
+describe('CodeBlockVanilla', () => {
+  const renderWithTheme = (ui: React.ReactElement) => {
+    return render(<VanillaExtractThemeProvider>{ui}</VanillaExtractThemeProvider>);
+  };
+
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: jest.fn().mockResolvedValue(undefined) },
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should render as a pre element', () => {
+    const { container } = renderWithTheme(
+      <CodeBlockVanilla lang="typescript" code={CODE_SNIPPET} />,
+    );
+    expect(container.querySelector('pre')).toBeInTheDocument();
+  });
+
+  it('should render the code content', () => {
+    const { container } = renderWithTheme(
+      <CodeBlockVanilla lang="typescript" code={CODE_SNIPPET} />,
+    );
+    // Prism splits tokens into separate spans, so check the full pre text content
+    expect(container.querySelector('pre')?.textContent).toContain('const');
+    expect(container.querySelector('pre')?.textContent).toContain('greet');
+  });
+
+  it('should apply custom className', () => {
+    const { container } = renderWithTheme(
+      <CodeBlockVanilla lang="typescript" code={CODE_SNIPPET} className="custom-class" />,
+    );
+    expect(container.querySelector('pre')?.className).toContain('custom-class');
+  });
+
+  it('should not render copy button when copyable is false', () => {
+    renderWithTheme(<CodeBlockVanilla lang="typescript" code={CODE_SNIPPET} />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('should render copy button when copyable is true', () => {
+    renderWithTheme(<CodeBlockVanilla lang="typescript" code={CODE_SNIPPET} copyable />);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('should have accessible label on copy button even without text props', () => {
+    renderWithTheme(<CodeBlockVanilla lang="typescript" code={CODE_SNIPPET} copyable />);
+    expect(screen.getByRole('button', { name: /copy/i })).toBeInTheDocument();
+  });
+
+  it('should not render visible text in copy button when copyText is omitted', () => {
+    renderWithTheme(<CodeBlockVanilla lang="typescript" code={CODE_SNIPPET} copyable />);
+    const button = screen.getByRole('button');
+    // AccessibleIcon adds exactly one hidden "Copy" label — no extra text node
+    expect(button.textContent).toBe('Copy');
+  });
+
+  it('should show copyText when provided', () => {
+    renderWithTheme(
+      <CodeBlockVanilla lang="typescript" code={CODE_SNIPPET} copyable copyText="Copy" />,
+    );
+    expect(screen.getByRole('button')).toHaveTextContent('Copy');
+  });
+
+  it('should copy code to clipboard when button is clicked', async () => {
+    renderWithTheme(<CodeBlockVanilla lang="typescript" code={CODE_SNIPPET} copyable />);
+    await userEvent.click(screen.getByRole('button'));
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(CODE_SNIPPET);
+    });
+  });
+
+  it('should show copiedText after clicking copy', async () => {
+    renderWithTheme(
+      <CodeBlockVanilla
+        lang="typescript"
+        code={CODE_SNIPPET}
+        copyable
+        copyText="Copy"
+        copiedText="Copied!"
+      />,
+    );
+    const button = screen.getByRole('button');
+    expect(button).toHaveTextContent('Copy');
+
+    await userEvent.click(button);
+    await waitFor(() => expect(button).toHaveTextContent('Copied!'));
+  });
+
+  it('should revert back to copy state after timeout', async () => {
+    jest.useFakeTimers('legacy');
+
+    renderWithTheme(
+      <CodeBlockVanilla
+        lang="typescript"
+        code={CODE_SNIPPET}
+        copyable
+        copyText="Copy"
+        copiedText="Copied!"
+      />,
+    );
+    const button = screen.getByRole('button');
+
+    // fireEvent.click is synchronous, so the clipboard Promise microtask hasn't
+    // fired yet when we hit `await Promise.resolve()` — that drains it while
+    // IS_REACT_ACT_ENVIRONMENT is still true, avoiding the act() warning.
+    await act(async () => {
+      fireEvent.click(button);
+      await Promise.resolve();
+    });
+    expect(button).toHaveTextContent('Copied!');
+
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    expect(button).toHaveTextContent('Copy');
+  });
+
+  it('should render without border when noBorder is true', () => {
+    const { container } = renderWithTheme(
+      <CodeBlockVanilla lang="typescript" code={CODE_SNIPPET} noBorder />,
+    );
+    expect(container.querySelector('pre')).toBeInTheDocument();
+  });
+
+  it('should apply wrapText prop', () => {
+    const { container } = renderWithTheme(
+      <CodeBlockVanilla lang="typescript" code={CODE_SNIPPET} wrapText />,
+    );
+    expect(container.querySelector('pre')).toBeInTheDocument();
+  });
+
+  it('should render different languages', () => {
+    const langs = ['javascript', 'json', 'yaml', 'bash', 'tsx'] as const;
+    langs.forEach((lang) => {
+      const { container, unmount } = renderWithTheme(
+        <CodeBlockVanilla lang={lang} code="const x = 1" />,
+      );
+      expect(container.querySelector('pre')).toBeInTheDocument();
+      unmount();
+    });
+  });
+
+  it('should apply custom style prop', () => {
+    const { container } = renderWithTheme(
+      <CodeBlockVanilla lang="typescript" code={CODE_SNIPPET} style={{ maxHeight: '200px' }} />,
+    );
+    const pre = container.querySelector('pre') as HTMLElement;
+    expect(pre.style.maxHeight).toBe('200px');
+  });
+
+  it('should forward ref to the pre element', () => {
+    const ref = React.createRef<HTMLPreElement>();
+    renderWithTheme(<CodeBlockVanilla ref={ref} lang="typescript" code={CODE_SNIPPET} />);
+    expect(ref.current).not.toBeNull();
+    expect(ref.current?.nodeName).toBe('PRE');
+  });
+
+  it('should pass through HTML attributes', () => {
+    renderWithTheme(
+      <CodeBlockVanilla
+        lang="typescript"
+        code={CODE_SNIPPET}
+        data-testid="my-codeblock"
+        aria-label="Code example"
+      />,
+    );
+    const pre = screen.getByTestId('my-codeblock');
+    expect(pre).toBeInTheDocument();
+    expect(pre).toHaveAttribute('aria-label', 'Code example');
+  });
+
+  it('should have no accessibility violations', async () => {
+    const { container } = renderWithTheme(
+      <CodeBlockVanilla lang="typescript" code={CODE_SNIPPET} copyable copyText="Copy" />,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  }, 10000);
+
+  it('should work with light theme', () => {
+    const { container } = render(
+      <VanillaExtractThemeProvider defaultTheme="light">
+        <CodeBlockVanilla lang="typescript" code={CODE_SNIPPET} />
+      </VanillaExtractThemeProvider>,
+    );
+    expect(container.querySelector('pre')).toBeInTheDocument();
+  });
+
+  it('should work with dark theme', () => {
+    const { container } = render(
+      <VanillaExtractThemeProvider defaultTheme="dark">
+        <CodeBlockVanilla lang="typescript" code={CODE_SNIPPET} />
+      </VanillaExtractThemeProvider>,
+    );
+    expect(container.querySelector('pre')).toBeInTheDocument();
+  });
+});

--- a/components/CodeBlock/CodeBlock.vanilla.tsx
+++ b/components/CodeBlock/CodeBlock.vanilla.tsx
@@ -1,0 +1,111 @@
+import { CheckIcon, CopyIcon } from '@radix-ui/react-icons';
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+import { Highlight, Language, themes } from 'prism-react-renderer';
+import React, { forwardRef, HTMLAttributes, useState } from 'react';
+
+import { CSSProps, processCSSProp } from '../../styles/cssProps';
+import { useVanillaExtractTheme } from '../../styles/themeContext';
+import { AccessibleIcon } from '../AccessibleIcon';
+import { ButtonVanilla } from '../Button';
+import { codeContent, copyButtonWrapper, pre, preNoBorder, wrapper } from './CodeBlock.vanilla.css';
+
+export interface CodeBlockVanillaProps
+  extends Omit<HTMLAttributes<HTMLPreElement>, 'css'>,
+    CSSProps {
+  lang: Language;
+  code: string;
+  copyable?: boolean;
+  copyText?: string;
+  copiedText?: string;
+  noBorder?: boolean;
+  wrapText?: boolean;
+}
+
+export const CodeBlockVanilla = forwardRef<HTMLPreElement, CodeBlockVanillaProps>(
+  (
+    {
+      lang,
+      code,
+      copyable = false,
+      copyText,
+      copiedText,
+      noBorder,
+      wrapText = false,
+      css,
+      style,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    const { colors, resolvedTheme } = useVanillaExtractTheme();
+    const prismTheme = resolvedTheme === 'dark' ? themes.nightOwl : themes.nightOwlLight;
+
+    const { style: cssStyles, vars } = processCSSProp(css, colors);
+    const mergedStyles = { ...cssStyles, ...style, ...assignInlineVars(vars) };
+
+    const [copied, setCopied] = useState(false);
+
+    const handleCopy = async () => {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    };
+
+    return (
+      <Highlight theme={prismTheme} code={code} language={lang}>
+        {({
+          className: highlightClass,
+          style: highlightStyle,
+          tokens,
+          getLineProps,
+          getTokenProps,
+        }) => (
+          <div className={wrapper}>
+            {copyable && (
+              <div className={copyButtonWrapper}>
+                <ButtonVanilla
+                  variant="secondary"
+                  ghost
+                  size="small"
+                  type="button"
+                  onClick={handleCopy}
+                  css={{ color: '$hiContrast', gap: '$1' }}
+                >
+                  <AccessibleIcon label={copied ? 'Copied' : 'Copy'}>
+                    {copied ? <CheckIcon /> : <CopyIcon />}
+                  </AccessibleIcon>
+                  {copied ? copiedText : copyText}
+                </ButtonVanilla>
+              </div>
+            )}
+            <pre
+              ref={ref}
+              className={[pre, noBorder ? preNoBorder : '', highlightClass, className]
+                .filter(Boolean)
+                .join(' ')}
+              style={{ ...highlightStyle, ...mergedStyles }}
+              {...props}
+            >
+              <div className={codeContent}>
+                {tokens.map((line, i) => (
+                  <div
+                    key={i}
+                    {...getLineProps({ line })}
+                    style={wrapText ? { whiteSpace: 'normal' } : undefined}
+                  >
+                    {line.map((token, key) => (
+                      <span key={key} {...getTokenProps({ token })} />
+                    ))}
+                  </div>
+                ))}
+              </div>
+            </pre>
+          </div>
+        )}
+      </Highlight>
+    );
+  },
+);
+
+CodeBlockVanilla.displayName = 'CodeBlockVanilla';

--- a/components/CodeBlock/CodeBlock.vanilla.tsx
+++ b/components/CodeBlock/CodeBlock.vanilla.tsx
@@ -19,6 +19,8 @@ export interface CodeBlockVanillaProps
   copiedText?: string;
   noBorder?: boolean;
   wrapText?: boolean;
+  colorScheme?: 'light' | 'dark';
+  maxHeight?: number | string;
 }
 
 export const CodeBlockVanilla = forwardRef<HTMLPreElement, CodeBlockVanillaProps>(
@@ -31,6 +33,8 @@ export const CodeBlockVanilla = forwardRef<HTMLPreElement, CodeBlockVanillaProps
       copiedText,
       noBorder,
       wrapText = false,
+      colorScheme,
+      maxHeight = 424,
       css,
       style,
       className,
@@ -39,7 +43,8 @@ export const CodeBlockVanilla = forwardRef<HTMLPreElement, CodeBlockVanillaProps
     ref,
   ) => {
     const { colors, resolvedTheme } = useVanillaExtractTheme();
-    const prismTheme = resolvedTheme === 'dark' ? themes.nightOwl : themes.nightOwlLight;
+    const effectiveScheme = colorScheme ?? resolvedTheme;
+    const prismTheme = effectiveScheme === 'dark' ? themes.nightOwl : themes.nightOwlLight;
 
     const { style: cssStyles, vars } = processCSSProp(css, colors);
     const mergedStyles = { ...cssStyles, ...style, ...assignInlineVars(vars) };
@@ -47,9 +52,13 @@ export const CodeBlockVanilla = forwardRef<HTMLPreElement, CodeBlockVanillaProps
     const [copied, setCopied] = useState(false);
 
     const handleCopy = async () => {
-      await navigator.clipboard.writeText(code);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
+      try {
+        await navigator.clipboard.writeText(code);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      } catch {
+        // clipboard write failed (e.g. permission denied) — leave UI unchanged
+      }
     };
 
     return (
@@ -84,7 +93,7 @@ export const CodeBlockVanilla = forwardRef<HTMLPreElement, CodeBlockVanillaProps
               className={[pre, noBorder ? preNoBorder : '', highlightClass, className]
                 .filter(Boolean)
                 .join(' ')}
-              style={{ ...highlightStyle, ...mergedStyles }}
+              style={{ maxHeight, ...highlightStyle, ...mergedStyles }}
               {...props}
             >
               <div className={codeContent}>

--- a/components/CodeBlock/CodeBlock.vanilla.tsx
+++ b/components/CodeBlock/CodeBlock.vanilla.tsx
@@ -7,7 +7,15 @@ import { CSSProps, processCSSProp } from '../../styles/cssProps';
 import { useVanillaExtractTheme } from '../../styles/themeContext';
 import { AccessibleIcon } from '../AccessibleIcon';
 import { ButtonVanilla } from '../Button';
-import { codeContent, copyButtonWrapper, pre, preNoBorder, wrapper } from './CodeBlock.vanilla.css';
+import {
+  codeContent,
+  copyButtonWrapper,
+  copyButtonWrapperBottom,
+  copyButtonWrapperTop,
+  pre,
+  preNoBorder,
+  wrapper,
+} from './CodeBlock.vanilla.css';
 
 export interface CodeBlockVanillaProps
   extends Omit<HTMLAttributes<HTMLPreElement>, 'css'>,
@@ -17,6 +25,7 @@ export interface CodeBlockVanillaProps
   copyable?: boolean;
   copyText?: string;
   copiedText?: string;
+  copyButtonAlign?: 'top' | 'bottom';
   noBorder?: boolean;
   wrapText?: boolean;
   colorScheme?: 'light' | 'dark';
@@ -31,6 +40,7 @@ export const CodeBlockVanilla = forwardRef<HTMLPreElement, CodeBlockVanillaProps
       copyable = false,
       copyText,
       copiedText,
+      copyButtonAlign = 'top',
       noBorder,
       wrapText = false,
       colorScheme,
@@ -72,7 +82,12 @@ export const CodeBlockVanilla = forwardRef<HTMLPreElement, CodeBlockVanillaProps
         }) => (
           <div className={wrapper}>
             {copyable && (
-              <div className={copyButtonWrapper}>
+              <div
+                className={[
+                  copyButtonWrapper,
+                  copyButtonAlign === 'bottom' ? copyButtonWrapperBottom : copyButtonWrapperTop,
+                ].join(' ')}
+              >
                 <ButtonVanilla
                   variant="secondary"
                   ghost
@@ -93,7 +108,12 @@ export const CodeBlockVanilla = forwardRef<HTMLPreElement, CodeBlockVanillaProps
               className={[pre, noBorder ? preNoBorder : '', highlightClass, className]
                 .filter(Boolean)
                 .join(' ')}
-              style={{ maxHeight, ...highlightStyle, ...mergedStyles }}
+              style={{
+                maxHeight,
+                ...highlightStyle,
+                backgroundColor: 'transparent',
+                ...mergedStyles,
+              }}
               {...props}
             >
               <div className={codeContent}>

--- a/components/CodeBlock/index.ts
+++ b/components/CodeBlock/index.ts
@@ -1,0 +1,5 @@
+export type { CodeBlockProps } from './CodeBlock';
+export { CodeBlock } from './CodeBlock';
+export type { CodeBlockVanillaProps } from './CodeBlock.vanilla';
+export { CodeBlockVanilla } from './CodeBlock.vanilla';
+export type { Language as CodeBlockLanguage } from 'prism-react-renderer';

--- a/components/FaencyProvider.tsx
+++ b/components/FaencyProvider.tsx
@@ -1,56 +1,8 @@
 import { Provider as TooltipProvider } from '@radix-ui/react-tooltip';
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React from 'react';
 
-type ColorScheme = 'light' | 'dark';
-
-function readDocumentTheme(): ColorScheme | null {
-  const el = document.documentElement;
-  if (el.classList.contains('dark')) return 'dark';
-  if (el.classList.contains('light')) return 'light';
-  const attr = el.dataset.theme;
-  if (attr === 'dark' || attr === 'light') return attr;
-  return null;
-}
-
-const ColorSchemeContext = createContext<ColorScheme>('light');
-
-function ColorSchemeProvider({ children }: { children: React.ReactNode }) {
-  const [scheme, setScheme] = useState<ColorScheme>(() => {
-    if (typeof window === 'undefined') return 'light';
-    return (
-      readDocumentTheme() ??
-      (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-    );
-  });
-
-  useEffect(() => {
-    const observer = new MutationObserver(() => {
-      const docTheme = readDocumentTheme();
-      if (docTheme) setScheme(docTheme);
-    });
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ['class', 'data-theme'],
-    });
-
-    const mq = window.matchMedia('(prefers-color-scheme: dark)');
-    const mqHandler = (e: MediaQueryListEvent) => {
-      if (!readDocumentTheme()) setScheme(e.matches ? 'dark' : 'light');
-    };
-    mq.addEventListener('change', mqHandler);
-
-    return () => {
-      observer.disconnect();
-      mq.removeEventListener('change', mqHandler);
-    };
-  }, []);
-
-  return <ColorSchemeContext.Provider value={scheme}>{children}</ColorSchemeContext.Provider>;
-}
-
-export function useColorScheme(): ColorScheme {
-  return useContext(ColorSchemeContext);
-}
+export { useColorScheme } from './colorSchemeContext';
+import { ColorSchemeProvider } from './colorSchemeContext';
 
 interface FaencyProviderProps {
   children?: React.ReactNode;

--- a/components/FaencyProvider.tsx
+++ b/components/FaencyProvider.tsx
@@ -1,10 +1,63 @@
 import { Provider as TooltipProvider } from '@radix-ui/react-tooltip';
-import React from 'react';
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type ColorScheme = 'light' | 'dark';
+
+function readDocumentTheme(): ColorScheme | null {
+  const el = document.documentElement;
+  if (el.classList.contains('dark')) return 'dark';
+  if (el.classList.contains('light')) return 'light';
+  const attr = el.dataset.theme;
+  if (attr === 'dark' || attr === 'light') return attr;
+  return null;
+}
+
+const ColorSchemeContext = createContext<ColorScheme>('light');
+
+function ColorSchemeProvider({ children }: { children: React.ReactNode }) {
+  const [scheme, setScheme] = useState<ColorScheme>(() => {
+    if (typeof window === 'undefined') return 'light';
+    return (
+      readDocumentTheme() ??
+      (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+    );
+  });
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      const docTheme = readDocumentTheme();
+      if (docTheme) setScheme(docTheme);
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'data-theme'],
+    });
+
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const mqHandler = (e: MediaQueryListEvent) => {
+      if (!readDocumentTheme()) setScheme(e.matches ? 'dark' : 'light');
+    };
+    mq.addEventListener('change', mqHandler);
+
+    return () => {
+      observer.disconnect();
+      mq.removeEventListener('change', mqHandler);
+    };
+  }, []);
+
+  return <ColorSchemeContext.Provider value={scheme}>{children}</ColorSchemeContext.Provider>;
+}
+
+export function useColorScheme(): ColorScheme {
+  return useContext(ColorSchemeContext);
+}
 
 interface FaencyProviderProps {
   children?: React.ReactNode;
 }
 
 export const FaencyProvider = ({ children }: FaencyProviderProps) => (
-  <TooltipProvider>{children}</TooltipProvider>
+  <TooltipProvider>
+    <ColorSchemeProvider>{children}</ColorSchemeProvider>
+  </TooltipProvider>
 );

--- a/components/FaencyProvider.tsx
+++ b/components/FaencyProvider.tsx
@@ -1,7 +1,6 @@
 import { Provider as TooltipProvider } from '@radix-ui/react-tooltip';
 import React from 'react';
 
-export { useColorScheme } from './colorSchemeContext';
 import { ColorSchemeProvider } from './colorSchemeContext';
 
 interface FaencyProviderProps {

--- a/components/List/List.stories.tsx
+++ b/components/List/List.stories.tsx
@@ -18,7 +18,20 @@ const Component: Meta<typeof Ul> = {
 const Template: StoryFn<typeof Ul> = (args) => (
   <Ul {...args}>
     <Li>Dashboard</Li>
-    <Li>Profile</Li>
+    <Li>
+      Profile
+      <Ul>
+        <Li>Account</Li>
+        <Li>
+          Security
+          <Ul>
+            <Li>Two-factor auth</Li>
+            <Li>Sessions</Li>
+          </Ul>
+        </Li>
+        <Li>Notifications</Li>
+      </Ul>
+    </Li>
     <Li>Settings</Li>
     <Li>Help</Li>
   </Ul>
@@ -29,19 +42,43 @@ export const Basic: StoryFn<typeof Ul> = Template.bind({});
 export const Checkboxes: StoryFn<typeof Ul> = (args) => (
   <Ul {...args}>
     <Li>
-      <input type="checkbox" disabled />
+      <input type="checkbox" />
       Dashboard
     </Li>
     <Li>
-      <input type="checkbox" disabled />
+      <input type="checkbox" />
       Profile
+      <Ul>
+        <Li>
+          <input type="checkbox" />
+          Account
+        </Li>
+        <Li>
+          <input type="checkbox" />
+          Security
+          <Ul>
+            <Li>
+              <input type="checkbox" />
+              Two-factor auth
+            </Li>
+            <Li>
+              <input type="checkbox" />
+              Sessions
+            </Li>
+          </Ul>
+        </Li>
+        <Li>
+          <input type="checkbox" />
+          Notifications
+        </Li>
+      </Ul>
     </Li>
     <Li>
-      <input type="checkbox" disabled />
+      <input type="checkbox" />
       Settings
     </Li>
     <Li>
-      <input type="checkbox" disabled />
+      <input type="checkbox" />
       Help
     </Li>
   </Ul>
@@ -50,7 +87,20 @@ export const Checkboxes: StoryFn<typeof Ul> = (args) => (
 export const Ordered: StoryFn<typeof Ol> = (args) => (
   <Ol {...args}>
     <Li>Dashboard</Li>
-    <Li>Profile</Li>
+    <Li>
+      Profile
+      <Ol>
+        <Li>Account</Li>
+        <Li>
+          Security
+          <Ol>
+            <Li>Two-factor auth</Li>
+            <Li>Sessions</Li>
+          </Ol>
+        </Li>
+        <Li>Notifications</Li>
+      </Ol>
+    </Li>
     <Li>Settings</Li>
     <Li>Help</Li>
   </Ol>

--- a/components/List/List.tsx
+++ b/components/List/List.tsx
@@ -29,7 +29,9 @@ const StyledListItemButton = styled('button', Flex, {
 
   // CUSTOM
   flexGrow: 1,
+  width: '100%',
   p: '$2',
+  position: 'relative',
   '&::before': {
     borderRadius: 'inherit',
     boxSizing: 'border-box',
@@ -91,16 +93,23 @@ const StyledUl = styled('ul', {
   p: 0,
   color: '$textDefault',
 
-  '&:has(li > span > input[type="checkbox"])': {
+  '&:has(> li > span > input[type="checkbox"])': {
     m: 0,
     listStyle: 'none',
-    li: {
+    '> li': {
       marginLeft: 0,
-      span: {
+      '> span': {
         input: {
           margin: '0 3px 0 0',
         },
       },
+    },
+  },
+  // Restore left-margin indentation when a nested checkbox list is inside a li
+  'li > &:has(> li > span > input[type="checkbox"])': {
+    marginLeft: '$2',
+    '> li': {
+      marginLeft: '$2',
     },
   },
 });
@@ -125,7 +134,13 @@ export interface ListProps extends ComponentProps<typeof StyledUl>, VariantProps
 }
 export const Ul = React.forwardRef<React.ElementRef<typeof StyledUl>, ListProps>(
   ({ interactive, ...props }, forwardedRef) => {
-    const contextValue = useMemo(() => ({ interactive: !!interactive }), [interactive]);
+    const parentContext = useContext(ListContext);
+    const contextValue = useMemo(
+      () => ({
+        interactive: interactive !== undefined ? !!interactive : parentContext.interactive,
+      }),
+      [interactive, parentContext.interactive],
+    );
 
     return (
       <ListContext.Provider value={contextValue}>
@@ -143,7 +158,13 @@ export interface OrderedListProps
 
 export const Ol = React.forwardRef<React.ElementRef<typeof StyledOl>, OrderedListProps>(
   ({ interactive, ...props }, forwardedRef) => {
-    const contextValue = useMemo(() => ({ interactive: !!interactive }), [interactive]);
+    const parentContext = useContext(ListContext);
+    const contextValue = useMemo(
+      () => ({
+        interactive: interactive !== undefined ? !!interactive : parentContext.interactive,
+      }),
+      [interactive, parentContext.interactive],
+    );
 
     return (
       <ListContext.Provider value={contextValue}>
@@ -174,6 +195,15 @@ export interface ListItemProps
 export const Li = React.forwardRef<React.ElementRef<typeof StyledLi>, ListItemProps>(
   ({ children, controls, align, justify, direction, gap, wrap, ...props }, forwardedRef) => {
     const { interactive } = useContext(ListContext);
+
+    const childArray = React.Children.toArray(children);
+    const nestedLists = childArray.filter(
+      (child) => React.isValidElement(child) && (child.type === Ul || child.type === Ol),
+    );
+    const inlineChildren = childArray.filter(
+      (child) => !(React.isValidElement(child) && (child.type === Ul || child.type === Ol)),
+    );
+
     return (
       <StyledLi {...props} ref={forwardedRef}>
         {interactive ? (
@@ -184,7 +214,7 @@ export const Li = React.forwardRef<React.ElementRef<typeof StyledLi>, ListItemPr
             gap={gap}
             wrap={wrap}
           >
-            {children}
+            {inlineChildren}
           </StyledListItemButton>
         ) : (
           <StyledSpan
@@ -195,9 +225,10 @@ export const Li = React.forwardRef<React.ElementRef<typeof StyledLi>, ListItemPr
             wrap={wrap}
             css={{ flexGrow: 1 }}
           >
-            {children}
+            {inlineChildren}
           </StyledSpan>
         )}
+        {nestedLists}
         {!!controls && <ControlsWrapper>{controls}</ControlsWrapper>}
       </StyledLi>
     );

--- a/components/colorSchemeContext.tsx
+++ b/components/colorSchemeContext.tsx
@@ -1,0 +1,52 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+export type ColorScheme = 'light' | 'dark';
+
+export function readDocumentTheme(): ColorScheme | null {
+  const el = document.documentElement;
+  if (el.classList.contains('dark')) return 'dark';
+  if (el.classList.contains('light')) return 'light';
+  const attr = el.dataset.theme;
+  if (attr === 'dark' || attr === 'light') return attr;
+  return null;
+}
+
+export const ColorSchemeContext = createContext<ColorScheme>('light');
+
+export function ColorSchemeProvider({ children }: { children: React.ReactNode }) {
+  const [scheme, setScheme] = useState<ColorScheme>(() => {
+    if (typeof window === 'undefined') return 'light';
+    return (
+      readDocumentTheme() ??
+      (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+    );
+  });
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      const docTheme = readDocumentTheme();
+      if (docTheme) setScheme(docTheme);
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'data-theme'],
+    });
+
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const mqHandler = (e: MediaQueryListEvent) => {
+      if (!readDocumentTheme()) setScheme(e.matches ? 'dark' : 'light');
+    };
+    mq.addEventListener('change', mqHandler);
+
+    return () => {
+      observer.disconnect();
+      mq.removeEventListener('change', mqHandler);
+    };
+  }, []);
+
+  return <ColorSchemeContext.Provider value={scheme}>{children}</ColorSchemeContext.Provider>;
+}
+
+export function useColorScheme(): ColorScheme {
+  return useContext(ColorSchemeContext);
+}

--- a/components/colorSchemeContext.tsx
+++ b/components/colorSchemeContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 
 export type ColorScheme = 'light' | 'dark';
 
-export function readDocumentTheme(): ColorScheme | null {
+function readDocumentTheme(): ColorScheme | null {
   const el = document.documentElement;
   if (el.classList.contains('dark')) return 'dark';
   if (el.classList.contains('light')) return 'light';
@@ -11,7 +11,7 @@ export function readDocumentTheme(): ColorScheme | null {
   return null;
 }
 
-export const ColorSchemeContext = createContext<ColorScheme>('light');
+const ColorSchemeContext = createContext<ColorScheme>('light');
 
 export function ColorSchemeProvider({ children }: { children: React.ReactNode }) {
   const [scheme, setScheme] = useState<ColorScheme>(() => {

--- a/index.ts
+++ b/index.ts
@@ -70,7 +70,8 @@ export {
   DropdownMenuTrigger,
 } from './components/DropdownMenu';
 export { Elevation, ElevationVanilla, elevationVariants } from './components/Elevation';
-export { FaencyProvider, useColorScheme } from './components/FaencyProvider';
+export { FaencyProvider } from './components/FaencyProvider';
+export { useColorScheme } from './components/colorSchemeContext';
 export { Flex, FlexVanilla } from './components/Flex';
 export { Grid, GridVanilla } from './components/Grid';
 export { H1, H2, H3, H4, H5, H6 } from './components/Heading';

--- a/index.ts
+++ b/index.ts
@@ -23,6 +23,12 @@ export { Badge, BADGE_COLORS_VANILLA, BadgeVanilla } from './components/Badge';
 export type { BlockquoteVanillaProps } from './components/Blockquote';
 export { Blockquote, BlockquoteVanilla } from './components/Blockquote';
 export { Box, BoxVanilla } from './components/Box';
+export type {
+  CodeBlockLanguage,
+  CodeBlockProps,
+  CodeBlockVanillaProps,
+} from './components/CodeBlock';
+export { CodeBlock, CodeBlockVanilla } from './components/CodeBlock';
 export type { BubbleVanillaProps } from './components/Bubble';
 export { Bubble, BubbleVanilla } from './components/Bubble';
 export type { ButtonVanillaProps } from './components/Button';
@@ -64,7 +70,7 @@ export {
   DropdownMenuTrigger,
 } from './components/DropdownMenu';
 export { Elevation, ElevationVanilla, elevationVariants } from './components/Elevation';
-export { FaencyProvider } from './components/FaencyProvider';
+export { FaencyProvider, useColorScheme } from './components/FaencyProvider';
 export { Flex, FlexVanilla } from './components/Flex';
 export { Grid, GridVanilla } from './components/Grid';
 export { H1, H2, H3, H4, H5, H6 } from './components/Heading';

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "np": "^8.0.4",
     "patch-package": "^8.0.0",
     "prettier": "^3.6.2",
+    "prism-react-renderer": "2.4.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "semantic-release": "^25.0.3",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        /^@vanilla-extract\//,
         'react/jsx-runtime',
         ...Object.keys(pkg.dependencies || {}),
         ...Object.keys(pkg.peerDependencies || {}),

--- a/yarn.lock
+++ b/yarn.lock
@@ -5946,6 +5946,7 @@ __metadata:
     np: "npm:^8.0.4"
     patch-package: "npm:^8.0.0"
     prettier: "npm:^3.6.2"
+    prism-react-renderer: "npm:2.4.1"
     react: "npm:18.2.0"
     react-dom: "npm:18.2.0"
     semantic-release: "npm:^25.0.3"
@@ -6253,6 +6254,13 @@ __metadata:
   version: 2.7.3
   resolution: "@types/prettier@npm:2.7.3"
   checksum: 10c0/0960b5c1115bb25e979009d0b44c42cf3d792accf24085e4bfce15aef5794ea042e04e70c2139a2c3387f781f18c89b5706f000ddb089e9a4a2ccb7536a2c5f0
+  languageName: node
+  linkType: hard
+
+"@types/prismjs@npm:^1.26.0":
+  version: 1.26.6
+  resolution: "@types/prismjs@npm:1.26.6"
+  checksum: 10c0/152a27500cb32b114edfb77f9d0dccd03bebc84828d1e92abacaf212b22d3ccdde041ce421dd58b6ec8461bbec7cd76ed5ee773cae4be7ca36a6dd4ddcf0f9e7
   languageName: node
   linkType: hard
 
@@ -8645,6 +8653,13 @@ __metadata:
   version: 1.0.4
   resolution: "clone@npm:1.0.4"
   checksum: 10c0/2176952b3649293473999a95d7bebfc9dc96410f6cbd3d2595cf12fd401f63a4bf41a7adbfd3ab2ff09ed60cb9870c58c6acdd18b87767366fabfc163700f13b
+  languageName: node
+  linkType: hard
+
+"clsx@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "clsx@npm:2.1.1"
+  checksum: 10c0/c4c8eb865f8c82baab07e71bfa8897c73454881c4f99d6bc81585aecd7c441746c1399d08363dc096c550cceaf97bd4ce1e8854e1771e9998d9f94c4fe075839
   languageName: node
   linkType: hard
 
@@ -16265,6 +16280,18 @@ __metadata:
   dependencies:
     parse-ms: "npm:^4.0.0"
   checksum: 10c0/555ea39a1de48a30601938aedb76d682871d33b6dee015281c37108921514b11e1792928b1648c2e5589acc73c8ef0fb5e585fb4c718e340a28b86799e90fb34
+  languageName: node
+  linkType: hard
+
+"prism-react-renderer@npm:2.4.1":
+  version: 2.4.1
+  resolution: "prism-react-renderer@npm:2.4.1"
+  dependencies:
+    "@types/prismjs": "npm:^1.26.0"
+    clsx: "npm:^2.0.0"
+  peerDependencies:
+    react: ">=16.0.0"
+  checksum: 10c0/ebbe8feb975224344bbdd046b3a937d121592dbe4b8f22ba0be31f5af37b9a8219f441138ef6cab1c5b96f2aa6b529015200959f7e5e85b60ca69c81d35edcd4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Description

## Summary

Introduces a new `CodeBlock` component with syntax highlighting and copy-to-clipboard support, alongside several QA-driven fixes across Button, List, AriaTable, and the build config.

### New: CodeBlock component
- Both Stitches (`CodeBlock`) and vanilla-extract (`CodeBlockVanilla`) implementations
- Syntax highlighting via `prism-react-renderer` with auto light/dark theme switching
- Optional copy button with configurable `copyText`/`copiedText` labels and 1.5 s revert
- `noBorder`, `wrapText`, `css`, and `style` prop support; ref-forwarded to `<pre>`
- Full test suite (`CodeBlock.vanilla.test.tsx`) covering copy behavior, fake-timer revert, accessibility (axe), ref forwarding, language variants, and theme support

### New: `useColorScheme` hook in `FaencyProvider`
- Reads `dark`/`light` class or `data-theme` attribute from `<html>`, falls back to `prefers-color-scheme`
- MutationObserver keeps the value reactive when the host app switches themes
- Storybook `preview.jsx` now toggles those classes on `<html>` so the hook resolves correctly in stories

### Bug fixes
- **Build**: marked all `@vanilla-extract/*` packages as external in Vite config so they aren't bundled into the library output
- **List**: fixed nested list support — `interactive` now propagates via context to child `Ul`/`Ol`; `Li` separates nested list nodes from inline content so they render outside the button/span wrapper; CSS selectors tightened to direct-child (`>`) combinators to avoid leaking styles into nested levels
- **AriaTable**: replaced `NonNullable<unknown>` with an explicit `{ children?: React.ReactNode; css?: CSS }` intersection in `AriaTableProps`
- **Button**: added `boxShadow: 'none'` to the `secondary + ghost` compound variant to prevent an inherited shadow from bleeding through

Fix: https://github.com/traefik/hub-issues/issues/2323

## Dependency changes

| Dependency | Version | State |
| --- | --- | --- |
| `prism-react-renderer` | `2.4.1` | Added |

## Breaking changes

None.

## How to test?

- [ ] Storybook: verify CodeBlock renders in light and dark modes, copy button toggles state and reverts after 1.5 s
- [ ] Storybook: verify nested `Ul`/`Ol` lists render and respect `interactive` at all nesting levels
- [ ] `yarn test:ci` passes (CodeBlock vanilla tests cover the copy/timer behavior)
- [ ] `yarn build` produces no bundled `@vanilla-extract` code in the output

## Good PR checkboxes

- [x] Change has been tested
- [x] Added/Updated tests
- [x] Added/Updated stories
- [x] PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
- [x] Labels are set
- [x] Project is linked

## Good Review checkboxes

<details>
<summary> ℹ️  Copy the snippet and paste in the review field to fill it</summary>

```markdown
- [ ] I've tested the changes
- [ ] I've agreed on the unit tests (soon to come)
- [ ] I've checked the stories
- [ ] I've read the code and understood it
- [ ] I don't have any more questions
- [ ] I've described any optional improvements
- [ ] I checked PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
```

</details>
