### PR TITLE
fix: copy button overlapping rules in CodeBlock

### DIFF
--- a/components/CodeBlock/CodeBlock.tsx
+++ b/components/CodeBlock/CodeBlock.tsx
@@ -195,7 +195,13 @@ export const CodeBlock = forwardRef<HTMLPreElement, CodeBlockProps>(
               noBorder={noBorder}
               {...props}
             >
-              <Box css={{ p: '$4', ...(copyable && isBottom ? { pb: '$7' } : {}) }}>
+              <Box
+                css={{
+                  p: '$4',
+                  ...(copyable && isLeft && isBottom ? { pb: '$7' } : {}),
+                  ...(copyable && isLeft && !isBottom ? { pt: '$7' } : {}),
+                }}
+              >
                 {tokens.map((line, i) => (
                   <div
                     key={i}

--- a/components/CodeBlock/CodeBlock.vanilla.css.ts
+++ b/components/CodeBlock/CodeBlock.vanilla.css.ts
@@ -23,6 +23,10 @@ export const codeContentBottomPadding = style({
   paddingBottom: tokens.space['7'],
 });
 
+export const codeContentTopPadding = style({
+  paddingTop: tokens.space['7'],
+});
+
 export const copyButtonWrapperTop = style({
   position: 'absolute',
   zIndex: 1,

--- a/components/CodeBlock/CodeBlock.vanilla.tsx
+++ b/components/CodeBlock/CodeBlock.vanilla.tsx
@@ -19,6 +19,7 @@ import { ButtonVanilla } from '../Button';
 import {
   codeContent,
   codeContentBottomPadding,
+  codeContentTopPadding,
   copyButtonWrapperBottomLeft,
   copyButtonWrapperBottomRight,
   copyButtonWrapperTop,
@@ -69,6 +70,9 @@ export const CodeBlockVanilla = forwardRef<HTMLPreElement, CodeBlockVanillaProps
     const effectiveScheme = colorScheme ?? resolvedTheme;
     const prismTheme = effectiveScheme === 'dark' ? themes.nightOwl : themes.nightOwlLight;
 
+    const isBottom = copyButtonAlign.includes('bottom');
+    const isLeft = copyButtonAlign.includes('left');
+
     const { style: cssStyles, vars } = processCSSProp(css, colors);
     const containerStyles = {
       position: 'relative' as const,
@@ -98,16 +102,14 @@ export const CodeBlockVanilla = forwardRef<HTMLPreElement, CodeBlockVanillaProps
       const wrapper = buttonWrapperRef.current;
       if (!pre || !wrapper) return;
 
-      const isLeftAlign = copyButtonAlign.includes('left');
-      const isBottomAlign = copyButtonAlign.includes('bottom');
       const borderH = noBorder ? 0 : 2;
 
       const update = () => {
-        if (!isLeftAlign) {
+        if (!isLeft) {
           const vScrollbar = Math.max(0, pre.offsetWidth - pre.clientWidth - borderH);
           wrapper.style.right = `${16 + vScrollbar}px`;
         }
-        if (isBottomAlign) {
+        if (isBottom) {
           const hScrollbar = Math.max(0, pre.offsetHeight - pre.clientHeight - borderH);
           wrapper.style.bottom = `${8 + hScrollbar}px`;
         }
@@ -117,7 +119,7 @@ export const CodeBlockVanilla = forwardRef<HTMLPreElement, CodeBlockVanillaProps
       const observer = new ResizeObserver(update);
       observer.observe(pre);
       return () => observer.disconnect();
-    }, [copyable, copyButtonAlign, noBorder]);
+    }, [copyable, isBottom, isLeft, noBorder]);
 
     const handleCopy = async () => {
       try {
@@ -130,8 +132,6 @@ export const CodeBlockVanilla = forwardRef<HTMLPreElement, CodeBlockVanillaProps
       }
     };
 
-    const isBottom = copyButtonAlign.includes('bottom');
-    const isLeft = copyButtonAlign.includes('left');
     const buttonPositionClass = isBottom
       ? isLeft
         ? copyButtonWrapperBottomLeft
@@ -189,7 +189,11 @@ export const CodeBlockVanilla = forwardRef<HTMLPreElement, CodeBlockVanillaProps
               {...props}
             >
               <div
-                className={[codeContent, copyable && isBottom ? codeContentBottomPadding : '']
+                className={[
+                  codeContent,
+                  copyable && isLeft && isBottom ? codeContentBottomPadding : '',
+                  copyable && isLeft && !isBottom ? codeContentTopPadding : '',
+                ]
                   .filter(Boolean)
                   .join(' ')}
               >


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Description

This PR fixes the positioning of the copy button in the top-left corner of the code block by adding the missing padding to prevent it from overlapping the code.

## Preview

<img width="560" height="240" alt="Screenshot 2026-04-21 alle 15 18 53" src="https://github.com/user-attachments/assets/32ebca9b-a574-4127-8c5d-1be01a3089dd" />

## Breaking changes

None

## Good PR checkboxes

- [x] Change has been tested
- [ ] Added/Updated tests
- [ ] Added/Updated stories
- [x] PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
- [x] Labels are set
- [x] Project is linked

## Good Review checkboxes

<details>
<summary> ℹ️  Copy the snippet and paste in the review field to fill it</summary>

```markdown
- [ ] I've tested the changes
- [ ] I've agreed on the unit tests (soon to come)
- [ ] I've checked the stories
- [ ] I've read the code and understood it
- [ ] I don't have any more questions
- [ ] I've described any optional improvements
- [ ] I checked PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
```

</details>
