### PR TITLE
feat: add $button radii token

### DIFF
--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -101,21 +101,21 @@ export const StyledButton = styled('button', BUTTON_BASE_STYLES, {
   variants: {
     size: {
       small: {
-        borderRadius: '$3',
+        borderRadius: '$button',
         height: '$5',
         px: '$2',
         fontSize: '$1',
         lineHeight: '$sizes$5',
       },
       medium: {
-        borderRadius: '$3',
+        borderRadius: '$button',
         height: '$6',
         px: '$3',
         fontSize: '$3',
         lineHeight: '$sizes$6',
       },
       large: {
-        borderRadius: '$3',
+        borderRadius: '$button',
         height: '$7',
         px: '$3',
         fontSize: '$3',

--- a/components/Button/Button.vanilla.css.ts
+++ b/components/Button/Button.vanilla.css.ts
@@ -101,7 +101,7 @@ export const buttonRecipe = recipe({
   variants: {
     size: {
       small: {
-        borderRadius: tokens.radii['3'],
+        borderRadius: tokens.radii.button,
         height: tokens.sizes['5'],
         paddingLeft: tokens.space['2'],
         paddingRight: tokens.space['2'],
@@ -109,7 +109,7 @@ export const buttonRecipe = recipe({
         lineHeight: tokens.sizes['5'],
       },
       medium: {
-        borderRadius: tokens.radii['3'],
+        borderRadius: tokens.radii.button,
         height: tokens.sizes['6'],
         paddingLeft: tokens.space['3'],
         paddingRight: tokens.space['3'],
@@ -117,7 +117,7 @@ export const buttonRecipe = recipe({
         lineHeight: tokens.sizes['6'],
       },
       large: {
-        borderRadius: tokens.radii['3'],
+        borderRadius: tokens.radii.button,
         height: tokens.sizes['7'],
         paddingLeft: tokens.space['3'],
         paddingRight: tokens.space['3'],

--- a/stitches.config.ts
+++ b/stitches.config.ts
@@ -120,7 +120,7 @@ const stitches = createStitches({
       12: '38px',
     },
     fontWeights: { light: 300, regular: 400, medium: 500, semiBold: 600, bold: 700 },
-    radii: { 1: '4px', 2: '6px', 3: '8px', 4: '12px', round: '50%', pill: '9999px' },
+    radii: { 1: '4px', 2: '6px', 3: '8px', 4: '12px', round: '50%', pill: '9999px', button: '8px' },
     zIndices: { 1: '100', 2: '200', 3: '300', 4: '400', max: '999' },
   },
   media: {

--- a/styles/cssProps.ts
+++ b/styles/cssProps.ts
@@ -100,6 +100,7 @@ function getRadiiValue(key: string): string {
     '4': '12px',
     round: '50%',
     pill: '9999px',
+    button: '8px',
   };
   return radiiMap[key] || '0px';
 }

--- a/styles/themes.css.ts
+++ b/styles/themes.css.ts
@@ -86,6 +86,7 @@ const baseThemeValues = {
     '4': '12px',
     round: '50%',
     pill: '9999px',
+    button: '8px',
   },
   zIndices: {
     '1': '100',

--- a/styles/tokens.css.ts
+++ b/styles/tokens.css.ts
@@ -224,6 +224,7 @@ export const tokens = createThemeContract({
     '4': null,
     round: null,
     pill: null,
+    button: null,
   },
   zIndices: {
     '1': null,


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Description

- Added a semantic `button` radii token (`8px`) to the Stitches radii scale (`stitches.config.ts`) and to the vanilla-extract token contract, theme, and CSS props resolver (`styles/tokens.css.ts`, `styles/themes.css.ts`, `styles/cssProps.ts`)
- Updated `Button.tsx` to use `borderRadius: '$button'` instead of `'$3'` for all three size variants (`small`, `medium`, `large`)
- Updated `Button.vanilla.css.ts` to use `tokens.radii.button` for the same variants, bringing the vanilla-extract implementation into alignment with the Stitches one

### Notes

The numeric token `$3` / `tokens.radii['3']` still resolves to `8px` and remains available for other uses. The new `button` token is a semantic alias that decouples Button's border radius from the numeric scale, making it independently adjustable going forward.

Fix https://github.com/traefik/hub-issues/issues/2687#issuecomment-4245992247

## Preview

No visual changes.

## Breaking changes

None.

## Good PR checkboxes

- [x] Change has been tested
- [ ] Added/Updated tests
- [ ] Added/Updated stories
- [x] PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
- [x] Labels are set
- [x] Project is linked

## Good Review checkboxes

<details>
<summary> ℹ️  Copy the snippet and paste in the review field to fill it</summary>

```markdown
- [ ] I've tested the changes
- [ ] I've agreed on the unit tests (soon to come)
- [ ] I've checked the stories
- [ ] I've read the code and understood it
- [ ] I don't have any more questions
- [ ] I've described any optional improvements
- [ ] I checked PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
```

</details>
