### PR TITLE
fix: add .js extensions to prismjs submodule imports for ESM compatibility

### DIFF
--- a/components/CodeBlock/prism-extend.ts
+++ b/components/CodeBlock/prism-extend.ts
@@ -3,21 +3,21 @@
 // components below can use it as their global Prism reference.
 import { Prism } from 'prism-react-renderer';
 import prismjs from 'prismjs';
-import 'prismjs/components/prism-bash';
-import 'prismjs/components/prism-csharp';
-import 'prismjs/components/prism-docker';
-import 'prismjs/components/prism-hcl';
-import 'prismjs/components/prism-http';
-import 'prismjs/components/prism-ini';
-import 'prismjs/components/prism-java';
-import 'prismjs/components/prism-markup-templating';
-import 'prismjs/components/prism-php';
-import 'prismjs/components/prism-powershell';
-import 'prismjs/components/prism-protobuf';
-import 'prismjs/components/prism-ruby';
-import 'prismjs/components/prism-scala';
-import 'prismjs/components/prism-shell-session';
-import 'prismjs/components/prism-toml';
+import 'prismjs/components/prism-bash.js';
+import 'prismjs/components/prism-csharp.js';
+import 'prismjs/components/prism-docker.js';
+import 'prismjs/components/prism-hcl.js';
+import 'prismjs/components/prism-http.js';
+import 'prismjs/components/prism-ini.js';
+import 'prismjs/components/prism-java.js';
+import 'prismjs/components/prism-markup-templating.js';
+import 'prismjs/components/prism-php.js';
+import 'prismjs/components/prism-powershell.js';
+import 'prismjs/components/prism-protobuf.js';
+import 'prismjs/components/prism-ruby.js';
+import 'prismjs/components/prism-scala.js';
+import 'prismjs/components/prism-shell-session.js';
+import 'prismjs/components/prism-toml.js';
 
 // Copy newly registered grammars from prismjs into prism-react-renderer's Prism.
 // Language component IIFEs register on prismjs's window.Prism, not on PrismRR.


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Description

Node's native ESM resolver (used by vitest without bundling) requires explicit file extensions. The extensionless prismjs imports in `prism-extend.ts` work fine in bundled contexts (Vite, webpack) but cause consumer projects' vitest runs to fail with:

```
Cannot find module '.../prismjs/components/prism-bash'
Did you mean to import "prismjs/components/prism-bash.js"?
```

This forced consumers to add `@traefik-labs/faency` to `server.deps.inline` in their vitest config, re-bundling the entire package on every test run.

This PR adds `.js` extensions to all prismjs language component imports.

Related to https://github.com/traefik/traefik-hub/pull/1068

## Preview

No visual changes.

## Dependency changes

None.

## Breaking changes

None.

## How to test?

Verify syntax highlighting still works correctly in Storybook: `yarn storybook` → navigate to the CodeBlock stories and confirm all languages (bash, docker, HCL, TOML, etc.) render with highlighting.

## Good PR checkboxes

- [x] Change has been tested
- [ ] Added/Updated tests
- [ ] Added/Updated stories
- [x] PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
- [x] Labels are set
- [x] Project is linked

## Good Review checkboxes

<details>
<summary> ℹ️  Copy the snippet and paste in the review field to fill it</summary>

```markdown
- [ ] I've tested the changes
- [ ] I've agreed on the unit tests (soon to come)
- [ ] I've checked the stories
- [ ] I've read the code and understood it
- [ ] I don't have any more questions
- [ ] I've described any optional improvements
- [ ] I checked PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
```

</details>
