### PR TITLE
fix: mark prism-extend as side-effectful to fix CJS language registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
   "files": [
     "dist"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "**/prism-extend.*",
+    "**/*.css"
+  ],
   "types": "dist/index.d.ts",
   "homepage": "https://traefik.github.io/faency/",
   "repository": "https://github.com/traefik/faency",


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Description

Additional Prism languages registered in `prism-extend.ts` worked locally and in Storybook but were silently dropped when hub-ui was built via Docker CI.

### Root cause

`package.json` had `"sideEffects": false`, which tells bundlers they can safely tree-shake any module that only re-exports values from externals. Rolldown exploited this when generating the CJS build: since `prism-extend.ts` re-exports `Prism` from `prism-react-renderer` (an external dependency), it inlined the import directly and never generated `prism-extend.cjs`, losing all the language registration side effects in the process.

The ESM build was unaffected because ESM preserves module identity more strictly. Local development was also unaffected because webpack skips tree-shaking in dev mode.

The combination that triggered the bug: **CJS resolution** (Next.js production build) + **tree-shaking enabled** (webpack production mode) + **`sideEffects: false`** (told rolldown the module was pure).

## How to test

1. Pull the updated Faency package into hub-ui
2. Run `next build` (or trigger a Docker CI build) this exercises the CJS path with tree-shaking enabled
3. Open a page that renders a `CodeBlock` with one of the previously broken languages (e.g. `hcl`, `toml`, `docker`, `bash`) and verify syntax highlighting is applied correctly
4. Confirm the same page works in the deployed Docker image

## Good PR checkboxes

- [x] Change has been tested
- [ ] Added/Updated tests
- [ ] Added/Updated stories
- [x] PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
- [x] Labels are set
- [x] Project is linked

## Good Review checkboxes

<details>
<summary> ℹ️  Copy the snippet and paste in the review field to fill it</summary>

```markdown
- [ ] I've tested the changes
- [ ] I've agreed on the unit tests (soon to come)
- [ ] I've checked the stories
- [ ] I've read the code and understood it
- [ ] I don't have any more questions
- [ ] I've described any optional improvements
- [ ] I checked PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
```

</details>
