### PR TITLE
ci: declare workflow-scope permissions on pr, pr-prod-build, add-to-project

### DIFF
--- a/.github/workflows/pr-prod-build.yaml
+++ b/.github/workflows/pr-prod-build.yaml
@@ -6,6 +6,9 @@ on:
 env:
   SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS: 72  # 3 days
 
+permissions:
+  contents: read
+
 jobs:
   faency:
     name: Production build test

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,6 +6,9 @@ on:
 env:
   SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS: 72  # 3 days
 
+permissions:
+  contents: read
+
 jobs:
   faency:
     name: Test, lint and build


### PR DESCRIPTION
Three workflows currently leave the workflow `GITHUB_TOKEN` scope implicit. This patch pins each to its minimum:

- `.github/workflows/add-to-project.yaml` -- `permissions: {}` (empty/deny-all). The job only runs `actions/add-to-project` with the `TRAEFIKINFRA_ADD2PROJECT` PAT; the implicit workflow token is unused.
- `.github/workflows/pr.yaml` -- `permissions: contents: read`. Lint + test + build via yarn. No GitHub API write.
- `.github/workflows/pr-prod-build.yaml` -- `permissions: contents: read`. Same shape as pr.yaml but for the production build path.

Both build workflows invoke SHA-pinned third-party actions (`actions/checkout`, `actions/setup-node`) and download `safe-chain` from a release with hash verification. Pinning the workflow scope to read narrows the blast radius if any of those upstreams is compromised (cf. tj-actions/changed-files CVE-2025-30066).

Style matches the existing workflow-level `permissions:` blocks in `main.yaml` (Pages deploy), `pr_title.yaml` (`pull-requests: read`), and `release.yaml` (publish).

`renovate.yaml` is deliberately out of scope: it uses `dawidd6/action-download-artifact@v20` to restore an artifact across runs and `actions/upload-artifact@v7` to publish a fresh one. The cache plumbing there deserves a more careful permissions story than a drive-by.