### PR TITLE
ci(renovate): pin vite-plugin-dts to <5 and react to <19

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -72,6 +72,17 @@
       matchManagers: [ 'npm' ],
       matchPackageNames: [ '@types/react', '@types/react-dom' ],
       enabled: false,
+    },
+    // vite-plugin-dts v5 splits its implementation into a separate `unplugin-dts` package
+    // and exposes its types exclusively via package.json `exports` subpaths, which require
+    // TypeScript's `moduleResolution: "node16" | "nodenext" | "bundler"`. Our tsconfig still
+    // uses classic `node` resolution (see the @ts-expect-error comments in vite.config.ts),
+    // so v5 fails to type-check with "has no default export". Keep pinned at 4.x until we
+    // migrate moduleResolution.
+    {
+      matchManagers: [ 'npm' ],
+      matchPackageNames: [ 'vite-plugin-dts' ],
+      allowedVersions: '<5.0.0',
     }
   ],
   semanticCommits: 'enabled',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -73,6 +73,13 @@
       matchPackageNames: [ '@types/react', '@types/react-dom' ],
       enabled: false,
     },
+    // React 19 is not yet supported across all consumers of Faency. Keep pinned at 18.x
+    // until downstream projects are ready to upgrade.
+    {
+      matchManagers: [ 'npm' ],
+      matchPackageNames: [ 'react', 'react-dom' ],
+      allowedVersions: '<19.0.0',
+    },
     // vite-plugin-dts v5 splits its implementation into a separate `unplugin-dts` package
     // and exposes its types exclusively via package.json `exports` subpaths, which require
     // TypeScript's `moduleResolution: "node16" | "nodenext" | "bundler"`. Our tsconfig still


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Description

`vite-plugin-dts` v5 splits its implementation into a separate `unplugin-dts` package and exposes types exclusively via `package.json` `exports` subpaths. That requires TypeScript's `moduleResolution` to be `node16`, `nodenext`, or `bundler`, but this project still uses classic `node` resolution (see the `@ts-expect-error` markers in `vite.config.ts`). The result is a `TS1192: Module 'vite-plugin-dts' has no default export` error in `vite.config.ts` under v5.

This PR adds a Renovate `packageRules` entry pinning `vite-plugin-dts` to `<5.0.0` until the `moduleResolution` migration lands, alongside an inline comment explaining the constraint and the unlock condition.

This PR also pins `react` and `react-dom` to `<19.0.0` in Renovate, since React 19 is not yet supported across all downstream consumers of Faency.

Related to https://github.com/traefik/faency/pull/5156

## Good PR checkboxes

- [x] Change has been tested
- [ ] Added/Updated tests
- [ ] Added/Updated stories
- [x] PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
- [x] Labels are set
- [x] Project is linked

## Good Review checkboxes

<details>
<summary> ℹ️  Copy the snippet and paste in the review field to fill it</summary>

```markdown
- [ ] I've tested the changes
- [ ] I've agreed on the unit tests (soon to come)
- [ ] I've checked the stories
- [ ] I've read the code and understood it
- [ ] I don't have any more questions
- [ ] I've described any optional improvements
- [ ] I checked PR follows [conventions](https://github.com/traefik/faency#how-to-contribute)
```

</details>
